### PR TITLE
Restyle site with warm gradient palette and revised navbar layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,15 +1,15 @@
 :root {
-  --background: #f7f8fa;
-  --surface: rgba(255, 255, 255, 0.92);
-  --surface-strong: #ffffff;
-  --text: #102a43;
-  --text-muted: #627d98;
-  --accent: #00a4bd;
-  --accent-strong: #00819b;
-  --accent-soft: rgba(0, 164, 189, 0.12);
-  --nav-bg: rgba(16, 24, 40, 0.72);
-  --nav-border: rgba(255, 255, 255, 0.08);
-  --shadow: 0 25px 45px rgba(15, 23, 42, 0.12);
+  --background: linear-gradient(135deg, #f97316 0%, #fbbf24 100%);
+  --surface: rgba(255, 249, 235, 0.92);
+  --surface-strong: #fff7d6;
+  --text: #0f3a5d;
+  --text-muted: rgba(15, 58, 93, 0.72);
+  --accent: #0f4c81;
+  --accent-strong: #0b355d;
+  --accent-soft: rgba(255, 200, 64, 0.22);
+  --nav-bg: rgba(255, 199, 44, 0.95);
+  --nav-border: rgba(15, 58, 93, 0.1);
+  --shadow: 0 25px 45px rgba(15, 58, 93, 0.18);
   --radius-lg: 24px;
   --radius-md: 18px;
   --radius-sm: 12px;
@@ -17,17 +17,17 @@
 }
 
 body.dark-mode {
-  --background: #0f172a;
-  --surface: rgba(15, 23, 42, 0.78);
-  --surface-strong: #111c34;
-  --text: #f1f5f9;
-  --text-muted: #cbd5f5;
-  --accent: #38bdf8;
-  --accent-strong: #0ea5e9;
-  --accent-soft: rgba(56, 189, 248, 0.15);
-  --nav-bg: rgba(12, 18, 32, 0.8);
-  --nav-border: rgba(148, 163, 184, 0.2);
-  --shadow: 0 24px 36px rgba(9, 10, 30, 0.45);
+  --background: linear-gradient(135deg, #0b1a2e 0%, #112d4e 100%);
+  --surface: rgba(17, 45, 78, 0.88);
+  --surface-strong: #0b1f3a;
+  --text: #e6f0ff;
+  --text-muted: rgba(198, 220, 255, 0.78);
+  --accent: #f59e0b;
+  --accent-strong: #f97316;
+  --accent-soft: rgba(245, 158, 11, 0.22);
+  --nav-bg: rgba(17, 45, 78, 0.95);
+  --nav-border: rgba(245, 208, 113, 0.25);
+  --shadow: 0 24px 36px rgba(4, 20, 41, 0.55);
 }
 
 * {
@@ -89,7 +89,7 @@ main {
   display: inline-flex;
   padding: 0.35rem 0.75rem;
   border-radius: 999px;
-  background: rgba(0, 164, 189, 0.08);
+  background: rgba(15, 76, 129, 0.12);
   color: var(--accent-strong);
   font-size: 0.75rem;
   letter-spacing: 0.08em;
@@ -108,17 +108,18 @@ main {
   position: relative;
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-start;
   gap: 1.5rem;
-  padding: 0.75rem clamp(1.5rem, 4vw, 4.5rem);
+  padding: clamp(1.1rem, 1.5vw, 1.35rem) clamp(1.5rem, 4vw, 4.5rem);
   background: var(--nav-bg);
   border-bottom: 1px solid var(--nav-border);
+  box-shadow: 0 18px 32px rgba(15, 58, 93, 0.18);
 }
 
 .nav__logo {
   font-weight: 700;
   letter-spacing: 0.05em;
-  color: #f8fafc;
+  color: var(--accent-strong);
   text-decoration: none;
   font-size: 1rem;
   text-transform: uppercase;
@@ -131,10 +132,11 @@ main {
   list-style: none;
   margin: 0;
   padding: 0;
+  margin-left: auto;
 }
 
 .nav__links a {
-  color: #e2e8f0;
+  color: var(--accent-strong);
   text-decoration: none;
   font-weight: 500;
   font-size: 0.95rem;
@@ -157,7 +159,7 @@ main {
 
 .nav__links a:hover,
 .nav__links a:focus-visible {
-  color: #ffffff;
+  color: var(--accent);
 }
 
 .nav__links a:hover::after,
@@ -181,15 +183,16 @@ main {
   display: block;
   width: 1.5rem;
   height: 2px;
-  background: #f8fafc;
+  background: var(--accent-strong);
   border-radius: 2px;
   transition: transform 0.3s ease;
 }
 
 .theme-toggle {
-  background: rgba(148, 163, 184, 0.12);
-  color: #f8fafc;
-  border: 1px solid rgba(148, 163, 184, 0.3);
+  margin-left: 1.5rem;
+  background: rgba(15, 58, 93, 0.12);
+  color: var(--accent-strong);
+  border: 1px solid rgba(15, 58, 93, 0.22);
   border-radius: 999px;
   padding: 0.45rem 0.75rem;
   cursor: pointer;
@@ -199,8 +202,18 @@ main {
 
 .theme-toggle:hover,
 .theme-toggle:focus-visible {
-  background: rgba(148, 163, 184, 0.22);
+  background: rgba(15, 58, 93, 0.18);
   transform: translateY(-1px);
+}
+
+body.dark-mode .theme-toggle {
+  background: rgba(245, 158, 11, 0.18);
+  border-color: rgba(245, 158, 11, 0.35);
+}
+
+body.dark-mode .theme-toggle:hover,
+body.dark-mode .theme-toggle:focus-visible {
+  background: rgba(245, 158, 11, 0.28);
 }
 
 .hero-slider {
@@ -208,7 +221,7 @@ main {
   height: min(86vh, 720px);
   min-height: 420px;
   overflow: hidden;
-  color: #ffffff;
+  color: #fff8eb;
   display: grid;
   align-items: center;
   padding: clamp(2rem, 5vw, 6rem) clamp(1.5rem, 5vw, 5rem);
@@ -219,7 +232,7 @@ main {
   content: "";
   position: absolute;
   inset: 0;
-  background: radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.25) 0%, rgba(15, 23, 42, 0.75) 55%, rgba(15, 23, 42, 0.95) 100%);
+  background: radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.22) 0%, rgba(249, 115, 22, 0.6) 55%, rgba(15, 58, 93, 0.85) 100%);
   mix-blend-mode: multiply;
   z-index: -1;
 }
@@ -228,7 +241,7 @@ main {
   content: "";
   position: absolute;
   inset: 0;
-  background: linear-gradient(135deg, rgba(15, 23, 42, 0.75) 0%, rgba(15, 23, 42, 0.2) 60%, rgba(15, 23, 42, 0.65) 100%);
+  background: linear-gradient(135deg, rgba(15, 58, 93, 0.75) 0%, rgba(249, 115, 22, 0.35) 60%, rgba(15, 58, 93, 0.7) 100%);
   z-index: -1;
 }
 
@@ -262,7 +275,7 @@ main {
   display: flex;
   flex-direction: column;
   justify-content: flex-end;
-  background: linear-gradient(180deg, rgba(15, 23, 42, 0) 15%, rgba(15, 23, 42, 0.6) 60%, rgba(15, 23, 42, 0.9) 95%);
+  background: linear-gradient(180deg, rgba(15, 58, 93, 0) 15%, rgba(15, 58, 93, 0.65) 60%, rgba(10, 39, 65, 0.92) 95%);
 }
 
 .hero-slide__overlay h2 {
@@ -273,7 +286,7 @@ main {
 .hero-slide__overlay p {
   margin: 0;
   max-width: 480px;
-  color: rgba(226, 232, 240, 0.9);
+  color: rgba(240, 249, 255, 0.88);
 }
 
 .hero-slider__content {
@@ -289,7 +302,7 @@ main {
 
 .hero-slider__content p {
   margin-bottom: 1.5rem;
-  color: rgba(226, 232, 240, 0.88);
+  color: rgba(255, 248, 235, 0.92);
 }
 
 .hero-slider__controls {
@@ -302,9 +315,9 @@ main {
 }
 
 .hero-slider__arrow {
-  background: rgba(15, 23, 42, 0.55);
-  color: #f8fafc;
-  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(15, 58, 93, 0.6);
+  color: #fff8eb;
+  border: 1px solid rgba(255, 248, 235, 0.35);
   border-radius: 999px;
   width: 44px;
   height: 44px;
@@ -315,7 +328,7 @@ main {
 
 .hero-slider__arrow:hover,
 .hero-slider__arrow:focus-visible {
-  background: rgba(15, 23, 42, 0.75);
+  background: rgba(10, 39, 65, 0.8);
   transform: translateY(-2px);
 }
 
@@ -333,14 +346,14 @@ main {
   width: 12px;
   height: 12px;
   border-radius: 999px;
-  border: 1px solid rgba(255, 255, 255, 0.65);
+  border: 1px solid rgba(255, 248, 235, 0.7);
   background: transparent;
   cursor: pointer;
   transition: background 0.3s ease, transform 0.3s ease;
 }
 
 .hero-slider__dot[aria-selected="true"] {
-  background: #ffffff;
+  background: #fff8eb;
   transform: scale(1.2);
 }
 
@@ -357,14 +370,14 @@ main {
   border-radius: var(--radius-lg);
   padding: clamp(1.5rem, 3vw, 2.5rem);
   box-shadow: var(--shadow);
-  border: 1px solid rgba(148, 163, 184, 0.12);
+  border: 1px solid rgba(15, 58, 93, 0.12);
   transition: transform 0.3s ease, box-shadow 0.3s ease;
 }
 
 .card:hover,
 .card:focus-within {
   transform: translateY(-4px);
-  box-shadow: 0 30px 60px rgba(15, 23, 42, 0.18);
+  box-shadow: 0 30px 60px rgba(15, 58, 93, 0.22);
 }
 
 .field {
@@ -382,7 +395,7 @@ main {
 .field textarea {
   padding: 0.65rem 0.85rem;
   border-radius: var(--radius-sm);
-  border: 1px solid rgba(148, 163, 184, 0.35);
+  border: 1px solid rgba(15, 58, 93, 0.3);
   font: inherit;
   background: var(--surface-strong);
   color: inherit;
@@ -393,7 +406,7 @@ main {
 .field textarea:focus {
   outline: none;
   border-color: var(--accent);
-  box-shadow: 0 0 0 3px rgba(0, 164, 189, 0.18);
+  box-shadow: 0 0 0 3px rgba(15, 76, 129, 0.18);
 }
 
 .button {
@@ -412,20 +425,20 @@ main {
 }
 
 .button--primary {
-  color: #ffffff;
+  color: #fff8eb;
   background: linear-gradient(135deg, var(--accent) 0%, var(--accent-strong) 100%);
-  box-shadow: 0 18px 25px rgba(0, 164, 189, 0.35);
+  box-shadow: 0 18px 25px rgba(15, 76, 129, 0.35);
 }
 
 .button--primary:hover,
 .button--primary:focus-visible {
   transform: translateY(-2px);
-  box-shadow: 0 22px 40px rgba(0, 164, 189, 0.45);
+  box-shadow: 0 22px 40px rgba(15, 76, 129, 0.45);
 }
 
 .button--ghost {
   background: transparent;
-  border: 1px solid rgba(148, 163, 184, 0.35);
+  border: 1px solid rgba(15, 58, 93, 0.3);
   color: inherit;
 }
 
@@ -447,7 +460,7 @@ main {
   padding: 0.9rem 1rem;
   border-radius: var(--radius-sm);
   background: var(--surface-strong);
-  border: 1px solid rgba(148, 163, 184, 0.25);
+  border: 1px solid rgba(15, 58, 93, 0.2);
   display: grid;
   gap: 0.35rem;
 }
@@ -502,14 +515,14 @@ main {
 }
 
 .cta {
-  background: linear-gradient(135deg, rgba(0, 164, 189, 0.16) 0%, rgba(0, 164, 189, 0.08) 100%);
+  background: linear-gradient(135deg, rgba(255, 200, 64, 0.25) 0%, rgba(15, 76, 129, 0.18) 100%);
   border-radius: var(--radius-lg);
   padding: clamp(1.75rem, 3vw, 2.5rem);
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 2rem;
-  border: 1px solid rgba(148, 163, 184, 0.18);
+  border: 1px solid rgba(15, 58, 93, 0.18);
   box-shadow: var(--shadow);
 }
 
@@ -534,7 +547,7 @@ main {
   display: grid;
   align-items: center;
   padding: clamp(3rem, 8vw, 6rem) clamp(1.5rem, 6vw, 5rem);
-  color: #ffffff;
+  color: #fff8eb;
   overflow: hidden;
 }
 
@@ -542,7 +555,7 @@ main {
   content: "";
   position: absolute;
   inset: 0;
-  background: linear-gradient(135deg, rgba(15, 23, 42, 0.75), rgba(15, 23, 42, 0.45));
+  background: linear-gradient(135deg, rgba(15, 58, 93, 0.82), rgba(249, 115, 22, 0.45));
   z-index: -1;
 }
 
@@ -561,7 +574,7 @@ main {
 .page-hero p {
   margin: 0;
   max-width: 640px;
-  color: rgba(226, 232, 240, 0.82);
+  color: rgba(255, 248, 235, 0.86);
 }
 
 .page-section {
@@ -590,7 +603,7 @@ main {
   padding: 1.75rem;
   background: var(--surface);
   border-radius: var(--radius-lg);
-  border: 1px solid rgba(148, 163, 184, 0.16);
+  border: 1px solid rgba(15, 58, 93, 0.16);
   box-shadow: var(--shadow);
 }
 
@@ -613,7 +626,7 @@ main {
   background: var(--surface);
   border-radius: var(--radius-lg);
   padding: 2rem;
-  border: 1px solid rgba(148, 163, 184, 0.18);
+  border: 1px solid rgba(15, 58, 93, 0.18);
   box-shadow: var(--shadow);
 }
 
@@ -670,8 +683,8 @@ main {
     position: absolute;
     top: 100%;
     right: clamp(1.5rem, 4vw, 4.5rem);
-    background: rgba(15, 23, 42, 0.92);
-    border: 1px solid rgba(148, 163, 184, 0.25);
+    background: var(--nav-bg);
+    border: 1px solid var(--nav-border);
     border-radius: var(--radius-md);
     padding: 1.1rem;
     flex-direction: column;
@@ -681,7 +694,8 @@ main {
     opacity: 0;
     pointer-events: none;
     transform: translateY(-10px);
-    transition: opacity 0.3s ease, transform 0.3s ease;
+    transition: opacity 0.3s ease, transform 0.3s ease, box-shadow 0.3s ease;
+    box-shadow: 0 12px 30px rgba(15, 58, 93, 0.18);
   }
 
   .nav__links.open {


### PR DESCRIPTION
## Summary
- refresh the global palette to use an orange gradient background, yellow navigation bar, and dark blue typography inspired by the provided reference image
- enlarge the navigation bar height, push the menu links toward the right edge, and update button, card, and CTA treatments to harmonize with the new palette
- retune hero overlays, hover states, and dark-mode variables so the updated colors remain cohesive across the experience

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68d31bd403f88330b49bb045961edf61