### PR TITLE
Add navbar support for local logo asset

### DIFF
--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title">
+  <title>Beyond the Reef placeholder logo</title>
+  <defs>
+    <linearGradient id="sunset" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#f97316" />
+      <stop offset="100%" stop-color="#fbbf24" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="12" fill="#0f4c81" />
+  <circle cx="44" cy="20" r="9" fill="url(#sunset)" />
+  <path d="M10 44c8-10 18-14 28-10 6 2 12 7 16 12v6H10z" fill="#fff7d6" opacity="0.9" />
+  <path d="M10 48c6-6 14-9 22-7 6 1.5 12 4.5 18 9v6H10z" fill="#ffffff" opacity="0.75" />
+</svg>

--- a/build-your-tours.html
+++ b/build-your-tours.html
@@ -14,11 +14,7 @@
     <nav class="nav" aria-label="Primary">
       <a class="nav__logo" href="index.html" aria-label="Beyond the Reef Mexico">
         <span class="nav__logo-icon" aria-hidden="true">
-          <svg viewBox="0 0 148 96" role="presentation" focusable="false">
-            <circle class="nav__logo-sun" cx="106" cy="28" r="18" />
-            <path class="nav__logo-wave" d="M16 80 Q52 28 92 34 Q112 38 126 50 Q116 48 110 50 Q96 54 96 66 Q96 76 108 78 Q120 80 130 72 L130 86 L16 86 Z" />
-            <rect class="nav__logo-wave" x="18" y="86" width="118" height="6" rx="3" />
-          </svg>
+          <img src="assets/logo.svg" alt="" />
         </span>
         <span class="nav__logo-text">
           <span class="nav__logo-title">Beyond the Reef</span>

--- a/contact.html
+++ b/contact.html
@@ -14,11 +14,7 @@
     <nav class="nav" aria-label="Primary">
       <a class="nav__logo" href="index.html" aria-label="Beyond the Reef Mexico">
         <span class="nav__logo-icon" aria-hidden="true">
-          <svg viewBox="0 0 148 96" role="presentation" focusable="false">
-            <circle class="nav__logo-sun" cx="106" cy="28" r="18" />
-            <path class="nav__logo-wave" d="M16 80 Q52 28 92 34 Q112 38 126 50 Q116 48 110 50 Q96 54 96 66 Q96 76 108 78 Q120 80 130 72 L130 86 L16 86 Z" />
-            <rect class="nav__logo-wave" x="18" y="86" width="118" height="6" rx="3" />
-          </svg>
+          <img src="assets/logo.svg" alt="" />
         </span>
         <span class="nav__logo-text">
           <span class="nav__logo-title">Beyond the Reef</span>

--- a/index.html
+++ b/index.html
@@ -14,11 +14,7 @@
     <nav class="nav" aria-label="Primary">
       <a class="nav__logo" href="index.html" aria-label="Beyond the Reef Mexico">
         <span class="nav__logo-icon" aria-hidden="true">
-          <svg viewBox="0 0 148 96" role="presentation" focusable="false">
-            <circle class="nav__logo-sun" cx="106" cy="28" r="18" />
-            <path class="nav__logo-wave" d="M16 80 Q52 28 92 34 Q112 38 126 50 Q116 48 110 50 Q96 54 96 66 Q96 76 108 78 Q120 80 130 72 L130 86 L16 86 Z" />
-            <rect class="nav__logo-wave" x="18" y="86" width="118" height="6" rx="3" />
-          </svg>
+          <img src="assets/logo.svg" alt="" />
         </span>
         <span class="nav__logo-text">
           <span class="nav__logo-title">Beyond the Reef</span>

--- a/our-story.html
+++ b/our-story.html
@@ -14,11 +14,7 @@
     <nav class="nav" aria-label="Primary">
       <a class="nav__logo" href="index.html" aria-label="Beyond the Reef Mexico">
         <span class="nav__logo-icon" aria-hidden="true">
-          <svg viewBox="0 0 148 96" role="presentation" focusable="false">
-            <circle class="nav__logo-sun" cx="106" cy="28" r="18" />
-            <path class="nav__logo-wave" d="M16 80 Q52 28 92 34 Q112 38 126 50 Q116 48 110 50 Q96 54 96 66 Q96 76 108 78 Q120 80 130 72 L130 86 L16 86 Z" />
-            <rect class="nav__logo-wave" x="18" y="86" width="118" height="6" rx="3" />
-          </svg>
+          <img src="assets/logo.svg" alt="" />
         </span>
         <span class="nav__logo-text">
           <span class="nav__logo-title">Beyond the Reef</span>

--- a/review.html
+++ b/review.html
@@ -14,11 +14,7 @@
     <nav class="nav" aria-label="Primary">
       <a class="nav__logo" href="index.html" aria-label="Beyond the Reef Mexico">
         <span class="nav__logo-icon" aria-hidden="true">
-          <svg viewBox="0 0 148 96" role="presentation" focusable="false">
-            <circle class="nav__logo-sun" cx="106" cy="28" r="18" />
-            <path class="nav__logo-wave" d="M16 80 Q52 28 92 34 Q112 38 126 50 Q116 48 110 50 Q96 54 96 66 Q96 76 108 78 Q120 80 130 72 L130 86 L16 86 Z" />
-            <rect class="nav__logo-wave" x="18" y="86" width="118" height="6" rx="3" />
-          </svg>
+          <img src="assets/logo.svg" alt="" />
         </span>
         <span class="nav__logo-text">
           <span class="nav__logo-title">Beyond the Reef</span>

--- a/style.css
+++ b/style.css
@@ -139,10 +139,11 @@ main {
   transition: color var(--transition);
 }
 
-.nav__logo-icon svg {
+.nav__logo-icon img {
   display: block;
   width: 100%;
-  height: auto;
+  height: 100%;
+  object-fit: contain;
 }
 
 .nav__logo-text {
@@ -166,25 +167,12 @@ main {
   color: var(--accent);
 }
 
-.nav__logo-wave {
-  fill: currentColor;
-}
-
-.nav__logo-sun {
-  fill: #fbbf24;
-  transition: fill var(--transition);
-}
-
 body.dark-mode .nav__logo-icon {
   color: var(--accent-strong);
 }
 
 body.dark-mode .nav__logo-subtitle {
   color: var(--accent-strong);
-}
-
-body.dark-mode .nav__logo-sun {
-  fill: var(--accent);
 }
 
 .nav__links {

--- a/tours.html
+++ b/tours.html
@@ -14,11 +14,7 @@
     <nav class="nav" aria-label="Primary">
       <a class="nav__logo" href="index.html" aria-label="Beyond the Reef Mexico">
         <span class="nav__logo-icon" aria-hidden="true">
-          <svg viewBox="0 0 148 96" role="presentation" focusable="false">
-            <circle class="nav__logo-sun" cx="106" cy="28" r="18" />
-            <path class="nav__logo-wave" d="M16 80 Q52 28 92 34 Q112 38 126 50 Q116 48 110 50 Q96 54 96 66 Q96 76 108 78 Q120 80 130 72 L130 86 L16 86 Z" />
-            <rect class="nav__logo-wave" x="18" y="86" width="118" height="6" rx="3" />
-          </svg>
+          <img src="assets/logo.svg" alt="" />
         </span>
         <span class="nav__logo-text">
           <span class="nav__logo-title">Beyond the Reef</span>


### PR DESCRIPTION
## Summary
- replace the inline SVG in the navbar with an <img> that loads `assets/logo.svg` on every page
- add a placeholder SVG asset so the logo can be replaced locally
- adjust navbar styling so external SVG logos scale correctly

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d3257227c883308ad4c8bc6b4104db