### PR TITLE
Add difference feature section beneath homepage hero

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,6 +104,86 @@
       </div>
     </section>
 
+    <section class="section section--difference" aria-labelledby="difference-heading">
+      <div class="difference">
+        <div class="section__intro difference__intro">
+          <h2 id="difference-heading">Forget Ordinary. Live the Difference.</h2>
+          <p>We design handcrafted adventures that move at your pace and deliver unforgettable moments from the first hello.</p>
+        </div>
+        <div class="difference__grid" role="list">
+          <article class="card difference-item" role="listitem">
+            <span class="difference-item__icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+                <rect x="3.5" y="6.75" width="17" height="11" rx="2.75" />
+                <path d="M9.5 6.75 10.9 4.5h2.2l1.4 2.25" />
+                <circle cx="12" cy="12.5" r="3.5" />
+              </svg>
+            </span>
+            <h3>Free professional photos</h3>
+            <p>Complimentary shots from our on-staff photographer capture every highlight of your day.</p>
+          </article>
+          <article class="card difference-item" role="listitem">
+            <span class="difference-item__icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+                <circle cx="12" cy="12" r="7" />
+                <path d="M9.5 12h6.75" />
+                <path d="m14.75 9.75 2.75 2.25-2.75 2.25" />
+              </svg>
+            </span>
+            <h3>Direct departures</h3>
+            <p>Private transport gets you exploring fast&mdash;no endless pickup loops or wasted hours.</p>
+          </article>
+          <article class="card difference-item" role="listitem">
+            <span class="difference-item__icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+                <circle cx="12" cy="12" r="7.25" />
+                <path d="M12 8.5v4l3 1.5" />
+              </svg>
+            </span>
+            <h3>Your time, your pace</h3>
+            <p>Choose the start time, linger longer, and savor each moment without following the crowd.</p>
+          </article>
+          <article class="card difference-item" role="listitem">
+            <span class="difference-item__icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+                <circle cx="12" cy="12" r="4" />
+                <path d="M12 4v2.5" />
+                <path d="M12 17.5V20" />
+                <path d="M4 12h2.5" />
+                <path d="M17.5 12H20" />
+                <path d="m6.75 6.75 1.75 1.75" />
+                <path d="m15.5 15.5 1.75 1.75" />
+                <path d="m17.25 6.75-1.75 1.75" />
+                <path d="m8.5 15.5-1.75 1.75" />
+              </svg>
+            </span>
+            <h3>Build your perfect day</h3>
+            <p>Mix diving, culture, cuisine, and downtime to craft an itinerary made just for you.</p>
+          </article>
+          <article class="card difference-item" role="listitem">
+            <span class="difference-item__icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M12 21c-4.25-2.2-6.5-5.15-6.5-8.75V7.25L12 4l6.5 3.25v5c0 3.6-2.25 6.55-6.5 8.75Z" />
+                <path d="m9.25 12.5 2.25 2.25 3.25-3.25" />
+              </svg>
+            </span>
+            <h3>Transparent pricing</h3>
+            <p>Everything you need is included up front&mdash;no hidden fees or surprise add-ons.</p>
+          </article>
+          <article class="card difference-item" role="listitem">
+            <span class="difference-item__icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M12 6.5 13.8 10l4 .55-2.9 2.85.7 4.1-3.6-1.9-3.6 1.9.7-4.1-2.9-2.85 4-.55Z" />
+                <path d="M8.5 13.4 7.25 20l4.75-1.8L16.75 20 15.5 13.4" />
+              </svg>
+            </span>
+            <h3>Top-reviewed hosts</h3>
+            <p>Five-star local experts bring insider knowledge and concierge-level service.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
     <section class="section" id="tour-builder">
       <div class="section__intro">
         <p class="eyebrow">Build your tour</p>

--- a/style.css
+++ b/style.css
@@ -409,6 +409,78 @@ body.dark-mode .theme-toggle:focus-visible {
   transform: scale(1.2);
 }
 
+.section--difference {
+  position: relative;
+  background: linear-gradient(135deg, rgba(255, 247, 232, 0.85) 0%, rgba(255, 223, 181, 0.45) 100%);
+  overflow: hidden;
+}
+
+body.dark-mode .section--difference {
+  background: linear-gradient(135deg, rgba(17, 45, 78, 0.85) 0%, rgba(249, 115, 22, 0.16) 100%);
+}
+
+.difference {
+  max-width: 1100px;
+  margin: 0 auto;
+  display: grid;
+  gap: clamp(2rem, 5vw, 3rem);
+}
+
+.difference__grid {
+  display: grid;
+  gap: clamp(1.5rem, 4vw, 2.5rem);
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.difference-item {
+  text-align: center;
+  display: grid;
+  gap: 0.85rem;
+  align-content: start;
+  padding-block: clamp(1.75rem, 4vw, 2.5rem);
+}
+
+.difference-item__icon {
+  width: 3.5rem;
+  aspect-ratio: 1 / 1;
+  border-radius: 50%;
+  margin: 0 auto 0.5rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(15, 76, 129, 0.12);
+  color: var(--accent-strong);
+  box-shadow: 0 12px 24px rgba(15, 76, 129, 0.18);
+}
+
+.difference-item__icon svg {
+  width: 65%;
+  height: 65%;
+}
+
+.difference-item h3 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.difference-item p {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.92rem;
+}
+
+.difference-item:hover,
+.difference-item:focus-within {
+  transform: translateY(-6px);
+  box-shadow: 0 32px 48px rgba(15, 58, 93, 0.22);
+}
+
+body.dark-mode .difference-item__icon {
+  background: rgba(245, 158, 11, 0.22);
+  color: var(--accent);
+  box-shadow: 0 12px 26px rgba(245, 158, 11, 0.2);
+}
+
 .tour-builder {
   display: grid;
   gap: clamp(1.5rem, 4vw, 2.5rem);


### PR DESCRIPTION
## Summary
- add a "Forget Ordinary. Live the Difference." section directly under the homepage slider with six curated selling points
- include inline SVG icons and descriptive copy for each benefit while keeping the layout accessible
- style the new difference grid to match the existing brand treatment and remain responsive in light and dark modes

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68d3388e163883309e1d1c081ea86fcc