### PR TITLE
Adjust spacing and layout for difference section

### DIFF
--- a/style.css
+++ b/style.css
@@ -413,6 +413,7 @@ body.dark-mode .theme-toggle:focus-visible {
   position: relative;
   background: linear-gradient(135deg, rgba(255, 247, 232, 0.85) 0%, rgba(255, 223, 181, 0.45) 100%);
   overflow: hidden;
+  padding-block-start: clamp(2rem, 3vw + 0.5rem, 3.25rem);
 }
 
 body.dark-mode .section--difference {
@@ -420,7 +421,7 @@ body.dark-mode .section--difference {
 }
 
 .difference {
-  max-width: 1100px;
+  max-width: min(100%, 1200px);
   margin: 0 auto;
   display: grid;
   gap: clamp(2rem, 5vw, 3rem);
@@ -429,7 +430,7 @@ body.dark-mode .section--difference {
 .difference__grid {
   display: grid;
   gap: clamp(1.5rem, 4vw, 2.5rem);
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
 }
 
 .difference-item {


### PR DESCRIPTION
## Summary
- reduce the top padding on the difference section to tighten the gap below the hero slider
- widen the difference grid container and shrink the minimum column width so all five cards sit on one row

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d341b9e8948330b4eb42777e775ed5