### PR TITLE
Refine Experience the Difference spacing and styling

### DIFF
--- a/style.css
+++ b/style.css
@@ -411,20 +411,24 @@ body.dark-mode .theme-toggle:focus-visible {
 
 .section--difference {
   position: relative;
-  background: linear-gradient(135deg, rgba(255, 247, 232, 0.85) 0%, rgba(255, 223, 181, 0.45) 100%);
+  background: linear-gradient(135deg, rgba(255, 249, 235, 0.96) 0%, rgba(255, 232, 209, 0.92) 100%);
   overflow: hidden;
-  padding-block-start: clamp(2rem, 3vw + 0.5rem, 3.25rem);
+  padding-block-start: clamp(1.5rem, 2vw + 0.5rem, 2.75rem);
 }
 
 body.dark-mode .section--difference {
-  background: linear-gradient(135deg, rgba(17, 45, 78, 0.85) 0%, rgba(249, 115, 22, 0.16) 100%);
+  background: linear-gradient(135deg, rgba(17, 45, 78, 0.9) 0%, rgba(9, 25, 44, 0.92) 100%);
 }
 
 .difference {
   max-width: min(100%, 1200px);
   margin: 0 auto;
   display: grid;
-  gap: clamp(2rem, 5vw, 3rem);
+  gap: clamp(1.5rem, 4vw, 2.25rem);
+}
+
+.difference__intro {
+  margin-bottom: clamp(1.25rem, 3vw, 2rem);
 }
 
 .difference__grid {


### PR DESCRIPTION
## Summary
- soften the Experience the Difference section background to better align with the surrounding palette
- tighten the spacing above the section and between the intro copy and feature cards

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68d3471091b0833091b55123930323f6