### PR TITLE
Adjust Experience the Difference spacing

### DIFF
--- a/style.css
+++ b/style.css
@@ -275,6 +275,7 @@ body.dark-mode .theme-toggle:focus-visible {
   display: grid;
   align-items: center;
   padding: clamp(2rem, 5vw, 6rem) clamp(1.5rem, 5vw, 5rem);
+  padding-bottom: clamp(1rem, 3vw, 2rem);
   isolation: isolate;
 }
 
@@ -411,13 +412,18 @@ body.dark-mode .theme-toggle:focus-visible {
 
 .section--difference {
   position: relative;
-  background: linear-gradient(135deg, rgba(255, 249, 235, 0.96) 0%, rgba(255, 232, 209, 0.92) 100%);
+  background: linear-gradient(
+    135deg,
+    rgba(249, 115, 22, 0.16) 0%,
+    rgba(251, 191, 36, 0.18) 48%,
+    rgba(15, 58, 93, 0.14) 100%
+  );
   overflow: hidden;
-  padding-block-start: clamp(1.5rem, 2vw + 0.5rem, 2.75rem);
+  padding-block-start: clamp(0.75rem, 2vw, 1.75rem);
 }
 
 body.dark-mode .section--difference {
-  background: linear-gradient(135deg, rgba(17, 45, 78, 0.9) 0%, rgba(9, 25, 44, 0.92) 100%);
+  background: linear-gradient(135deg, rgba(17, 45, 78, 0.85) 0%, rgba(9, 25, 44, 0.92) 100%);
 }
 
 .difference {
@@ -843,7 +849,7 @@ body.dark-mode .difference-item__icon {
 
   .hero-slider {
     padding-top: 6rem;
-    padding-bottom: 4rem;
+    padding-bottom: 2.5rem;
   }
 
   .hero-slider__controls {


### PR DESCRIPTION
## Summary
- reduce the hero slider's bottom padding to tighten the gap before the Experience the Difference section on all viewports
- update the section's top padding and gradient background so it blends with the site's warm palette
- refine the mobile hero slider spacing to maintain the reduced separation on smaller screens

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d34a0fed1883309d98a1ed5c135331