### PR TITLE
Adjust floating contact positioning

### DIFF
--- a/style.css
+++ b/style.css
@@ -829,7 +829,7 @@ body.dark-mode .difference-item__icon {
 
 .floating-contact {
   position: fixed;
-  bottom: 1.5rem;
+  bottom: 0.75rem;
   right: 0.75rem;
   display: flex;
   flex-direction: column;
@@ -850,7 +850,8 @@ body.dark-mode .difference-item__icon {
   border: 1px solid rgba(255, 248, 235, 0.22);
   pointer-events: auto;
   min-width: 0;
-  width: clamp(220px, 28vw + 140px, 280px);
+  width: auto;
+  max-width: 280px;
   transition: transform var(--transition), box-shadow var(--transition), background var(--transition);
   backdrop-filter: blur(14px);
 }
@@ -1023,11 +1024,11 @@ body.dark-mode .floating-contact__link:focus-visible {
 
   .floating-contact {
     right: 0.5rem;
-    bottom: 1rem;
+    bottom: 0.6rem;
   }
 
   .floating-contact__link {
-    width: clamp(200px, 60vw, 260px);
+    max-width: min(60vw, 260px);
     padding: 0.65rem 0.85rem;
     gap: 0.65rem;
   }
@@ -1051,11 +1052,11 @@ body.dark-mode .floating-contact__link:focus-visible {
 @media (max-width: 420px) {
   .floating-contact {
     right: 0.4rem;
-    bottom: 0.75rem;
+    bottom: 0.5rem;
   }
 
   .floating-contact__link {
-    width: min(92vw, 260px);
+    max-width: min(88vw, 240px);
     padding: 0.6rem 0.75rem;
   }
 }


### PR DESCRIPTION
## Summary
- bring the floating contact buttons slightly closer to the bottom edge across breakpoints
- let the WhatsApp and Instagram buttons size to their content so the pills no longer include large empty tails

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d3553a7e488330a04e6147d741c616