### PR TITLE
Replace theme toggle icons with text labels

### DIFF
--- a/build-your-tours.html
+++ b/build-your-tours.html
@@ -34,7 +34,7 @@
         <li><a href="our-story.html">Our Story</a></li>
         <li><a href="contact.html">Contact</a></li>
       </ul>
-      <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">🌞</button>
+      <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">Dark mode</button>
     </nav>
   </header>
 

--- a/contact.html
+++ b/contact.html
@@ -34,7 +34,7 @@
         <li><a href="our-story.html">Our Story</a></li>
         <li><a href="contact.html" aria-current="page">Contact</a></li>
       </ul>
-      <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">🌞</button>
+      <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">Dark mode</button>
     </nav>
   </header>
 

--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
         <li><a href="our-story.html">Our Story</a></li>
         <li><a href="contact.html">Contact</a></li>
       </ul>
-      <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">🌞</button>
+      <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">Dark mode</button>
     </nav>
   </header>
 

--- a/our-story.html
+++ b/our-story.html
@@ -38,7 +38,7 @@
         <li><a href="our-story.html" aria-current="page">Our Story</a></li>
         <li><a href="contact.html">Contact</a></li>
       </ul>
-      <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">🌞</button>
+      <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">Dark mode</button>
     </nav>
   </header>
 

--- a/review.html
+++ b/review.html
@@ -38,7 +38,7 @@
         <li><a href="our-story.html">Our Story</a></li>
         <li><a href="contact.html">Contact</a></li>
       </ul>
-      <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">🌞</button>
+      <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">Dark mode</button>
     </nav>
   </header>
 

--- a/script.js
+++ b/script.js
@@ -38,15 +38,18 @@ function setupThemeToggle(prefersDark) {
   const storedTheme = localStorage.getItem('preferred-theme');
   const shouldUseDark = storedTheme ? storedTheme === 'dark' : prefersDark?.matches;
 
+  toggle.textContent = 'Dark mode';
+  toggle.setAttribute('aria-pressed', 'false');
+
   if (shouldUseDark) {
     document.body.classList.add('dark-mode');
-    toggle.textContent = '🌙';
+    toggle.textContent = 'Light mode';
     toggle.setAttribute('aria-pressed', 'true');
   }
 
   toggle.addEventListener('click', () => {
     const isDark = document.body.classList.toggle('dark-mode');
-    toggle.textContent = isDark ? '🌙' : '🌞';
+    toggle.textContent = isDark ? 'Light mode' : 'Dark mode';
     toggle.setAttribute('aria-pressed', isDark ? 'true' : 'false');
     localStorage.setItem('preferred-theme', isDark ? 'dark' : 'light');
   });
@@ -54,7 +57,7 @@ function setupThemeToggle(prefersDark) {
   prefersDark?.addEventListener?.('change', (event) => {
     if (!localStorage.getItem('preferred-theme')) {
       document.body.classList.toggle('dark-mode', event.matches);
-      toggle.textContent = event.matches ? '🌙' : '🌞';
+      toggle.textContent = event.matches ? 'Light mode' : 'Dark mode';
       toggle.setAttribute('aria-pressed', event.matches ? 'true' : 'false');
     }
   });


### PR DESCRIPTION
## Summary
- initialize the theme toggle with descriptive text labels that reflect the current mode
- swap the sun/moon emoji in the header toggle for "Dark mode" and "Light mode" text across all pages

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d36602013483308310fbc866c6b62a