### PR TITLE
Add bilingual toggle and translations

### DIFF
--- a/build-your-tours.html
+++ b/build-your-tours.html
@@ -3,15 +3,15 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Build Your Tours | Beyond the Reef Adventures</title>
+  <title data-i18n="page.title">Build Your Tours | Beyond the Reef Adventures</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="style.css" />
 </head>
-<body>
+<body data-page="tours">
   <header class="site-header">
-    <nav class="nav" aria-label="Primary">
+    <nav class="nav" aria-label="Primary" data-i18n="nav.primary" data-i18n-attr="aria-label">
       <a class="nav__logo" href="index.html" aria-label="Beyond the Reef Mexico">
         <span class="nav__logo-icon" aria-hidden="true">
           <img src="assets/logo.svg" alt="" />
@@ -22,19 +22,20 @@
         </span>
       </a>
       <button class="nav__toggle" type="button" aria-expanded="false" aria-controls="primary-navigation" data-nav-toggle>
-        <span class="sr-only">Toggle navigation</span>
+        <span class="sr-only" data-i18n="nav.toggle">Toggle navigation</span>
         <span></span>
         <span></span>
         <span></span>
       </button>
       <ul class="nav__links" id="primary-navigation">
-        <li><a href="index.html">Home</a></li>
-        <li><a href="build-your-tours.html" aria-current="page">Create Your Experience</a></li>
-        <li><a href="review.html">Reviews</a></li>
-        <li><a href="our-story.html">Our Story</a></li>
-        <li><a href="contact.html">Contact</a></li>
+        <li><a href="index.html" data-i18n="nav.home">Home</a></li>
+        <li><a href="build-your-tours.html" aria-current="page" data-i18n="nav.create">Create Your Experience</a></li>
+        <li><a href="review.html" data-i18n="nav.reviews">Reviews</a></li>
+        <li><a href="our-story.html" data-i18n="nav.story">Our Story</a></li>
+        <li><a href="contact.html" data-i18n="nav.contact">Contact</a></li>
       </ul>
-      <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">Dark mode</button>
+      <button class="nav__control language-toggle" type="button" data-language-toggle aria-pressed="false">Español 🇲🇽</button>
+      <button class="nav__control theme-toggle" type="button" data-theme-toggle aria-pressed="false">Dark mode</button>
     </nav>
   </header>
 
@@ -42,62 +43,73 @@
     <section class="page-hero">
       <img class="page-hero__background" src="https://images.unsplash.com/photo-1500375592092-40eb2168fd21?auto=format&fit=crop&w=1600&q=80" alt="Custom boat on turquoise water" />
       <div>
-        <p class="eyebrow">Build your tour</p>
-        <h1>Design experiences as unique as your crew</h1>
-        <p>Drag and drop curated activities, refine pacing, and invite your travel companions to collaborate in real time.</p>
+        <p class="eyebrow" data-i18n="tours.hero.eyebrow">Build your tour</p>
+        <h1 data-i18n="tours.hero.heading">Design experiences as unique as your crew</h1>
+        <p data-i18n="tours.hero.copy">Drag and drop curated activities, refine pacing, and invite your travel companions to collaborate in real time.</p>
       </div>
     </section>
 
     <section class="page-section">
       <div class="page-grid">
         <article class="card">
-          <h2>Custom combinations</h2>
-          <p>Mix scuba dives, culinary surprises, and remote hikes across islands. Our smart planner orchestrates logistics so you can focus on the fun.</p>
+          <h2 data-i18n="tours.grid.custom.title">Custom combinations</h2>
+          <p data-i18n="tours.grid.custom.copy">Mix scuba dives, culinary surprises, and remote hikes across islands. Our smart planner orchestrates logistics so you can focus on the fun.</p>
         </article>
         <article class="card">
-          <h2>Smart pacing</h2>
-          <p>We balance high-energy adventures with restorative interludes, ensuring every guest has time to recharge.</p>
+          <h2 data-i18n="tours.grid.pacing.title">Smart pacing</h2>
+          <p data-i18n="tours.grid.pacing.copy">We balance high-energy adventures with restorative interludes, ensuring every guest has time to recharge.</p>
         </article>
         <article class="card">
-          <h2>Co-create instantly</h2>
-          <p>Share a private link so your crew can vote, comment, or add new ideas. Our concierges can jump in live to fine-tune.</p>
+          <h2 data-i18n="tours.grid.collab.title">Co-create instantly</h2>
+          <p data-i18n="tours.grid.collab.copy">Share a private link so your crew can vote, comment, or add new ideas. Our concierges can jump in live to fine-tune.</p>
         </article>
       </div>
     </section>
 
     <section class="page-section">
-      <h2>How the custom builder works</h2>
+      <h2 data-i18n="tours.steps.heading">How the custom builder works</h2>
       <ol class="grid" style="counter-reset: steps; list-style: none; padding: 0; margin: 0;">
         <li class="card" style="position: relative; padding-left: 3.5rem;">
           <span style="position: absolute; left: 1.5rem; top: 1.75rem; font-size: 1.1rem; font-weight: 700; color: var(--accent);">1</span>
-          <h3>Tell us about your dream</h3>
-          <p>Answer a few questions or import a mood board. We use your vibe to pre-select experiences.</p>
+          <h3 data-i18n="tours.steps.one.title">Tell us about your dream</h3>
+          <p data-i18n="tours.steps.one.copy">Answer a few questions or import a mood board. We use your vibe to pre-select experiences.</p>
         </li>
         <li class="card" style="position: relative; padding-left: 3.5rem;">
           <span style="position: absolute; left: 1.5rem; top: 1.75rem; font-size: 1.1rem; font-weight: 700; color: var(--accent);">2</span>
-          <h3>Remix the plan</h3>
-          <p>Drag items between days, adjust timing, and add bespoke requests like photographers or private chefs.</p>
+          <h3 data-i18n="tours.steps.two.title">Remix the plan</h3>
+          <p data-i18n="tours.steps.two.copy">Drag items between days, adjust timing, and add bespoke requests like photographers or private chefs.</p>
         </li>
         <li class="card" style="position: relative; padding-left: 3.5rem;">
           <span style="position: absolute; left: 1.5rem; top: 1.75rem; font-size: 1.1rem; font-weight: 700; color: var(--accent);">3</span>
-          <h3>Lock it in</h3>
-          <p>Collaborate with your concierge to finalize transfers, payments, and on-island support.</p>
+          <h3 data-i18n="tours.steps.three.title">Lock it in</h3>
+          <p data-i18n="tours.steps.three.copy">Collaborate with your concierge to finalize transfers, payments, and on-island support.</p>
         </li>
       </ol>
     </section>
   </main>
 
   <footer class="site-footer">
-    <p>&copy; <span id="current-year"></span> Beyond the Reef Adventures. All rights reserved.</p>
+    <p>
+      &copy; <span id="current-year"></span>
+      <span data-i18n="footer.rights">Beyond the Reef Adventures. All rights reserved.</span>
+    </p>
   </footer>
 
-  <div class="floating-contact" role="complementary" aria-label="Quick contact options">
+  <div
+    class="floating-contact"
+    role="complementary"
+    aria-label="Quick contact options"
+    data-i18n="floatingContact.aria"
+    data-i18n-attr="aria-label"
+  >
     <a
       class="floating-contact__link floating-contact__link--whatsapp"
       href="https://wa.me/529841670697"
       target="_blank"
       rel="noopener noreferrer"
       aria-label="Chat on WhatsApp"
+      data-i18n="floatingContact.whatsappAria"
+      data-i18n-attr="aria-label"
     >
       <span class="floating-contact__icon" aria-hidden="true">
         <svg viewBox="0 0 24 24" role="presentation" focusable="false" stroke-linecap="round" stroke-linejoin="round">
@@ -118,6 +130,8 @@
       target="_blank"
       rel="noopener noreferrer"
       aria-label="Open Instagram"
+      data-i18n="floatingContact.instagramAria"
+      data-i18n-attr="aria-label"
     >
       <span class="floating-contact__icon" aria-hidden="true">
         <svg viewBox="0 0 24 24" role="presentation" focusable="false" stroke-linecap="round" stroke-linejoin="round">

--- a/contact.html
+++ b/contact.html
@@ -3,15 +3,15 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Contact | Beyond the Reef Adventures</title>
+  <title data-i18n="page.title">Contact | Beyond the Reef Adventures</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="style.css" />
 </head>
-<body>
+<body data-page="contact">
   <header class="site-header">
-    <nav class="nav" aria-label="Primary">
+    <nav class="nav" aria-label="Primary" data-i18n="nav.primary" data-i18n-attr="aria-label">
       <a class="nav__logo" href="index.html" aria-label="Beyond the Reef Mexico">
         <span class="nav__logo-icon" aria-hidden="true">
           <img src="assets/logo.svg" alt="" />
@@ -22,19 +22,20 @@
         </span>
       </a>
       <button class="nav__toggle" type="button" aria-expanded="false" aria-controls="primary-navigation" data-nav-toggle>
-        <span class="sr-only">Toggle navigation</span>
+        <span class="sr-only" data-i18n="nav.toggle">Toggle navigation</span>
         <span></span>
         <span></span>
         <span></span>
       </button>
       <ul class="nav__links" id="primary-navigation">
-        <li><a href="index.html">Home</a></li>
-        <li><a href="build-your-tours.html">Create Your Experience</a></li>
-        <li><a href="review.html">Reviews</a></li>
-        <li><a href="our-story.html">Our Story</a></li>
-        <li><a href="contact.html" aria-current="page">Contact</a></li>
+        <li><a href="index.html" data-i18n="nav.home">Home</a></li>
+        <li><a href="build-your-tours.html" data-i18n="nav.create">Create Your Experience</a></li>
+        <li><a href="review.html" data-i18n="nav.reviews">Reviews</a></li>
+        <li><a href="our-story.html" data-i18n="nav.story">Our Story</a></li>
+        <li><a href="contact.html" aria-current="page" data-i18n="nav.contact">Contact</a></li>
       </ul>
-      <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">Dark mode</button>
+      <button class="nav__control language-toggle" type="button" data-language-toggle aria-pressed="false">Español 🇲🇽</button>
+      <button class="nav__control theme-toggle" type="button" data-theme-toggle aria-pressed="false">Dark mode</button>
     </nav>
   </header>
 
@@ -42,59 +43,77 @@
     <section class="page-hero">
       <img class="page-hero__background" src="https://images.unsplash.com/photo-1522356308333-94b4958341c5?auto=format&fit=crop&w=1600&q=80" alt="Message in a bottle on a beach" />
       <div>
-        <p class="eyebrow">Say aloha</p>
-        <h1>Let’s bring your next adventure to life</h1>
-        <p>Share a few details and our concierge team will respond within one business day with ideas and availability.</p>
+        <p class="eyebrow" data-i18n="contact.hero.eyebrow">Say aloha</p>
+        <h1 data-i18n="contact.hero.heading">Let’s bring your next adventure to life</h1>
+        <p data-i18n="contact.hero.copy">Share a few details and our concierge team will respond within one business day with ideas and availability.</p>
       </div>
     </section>
 
     <section class="page-section">
       <div class="contact-grid">
         <article class="contact-card">
-          <h3>Start a conversation</h3>
-          <p>Email <a href="mailto:hello@beyondthereef.com">hello@beyondthereef.com</a></p>
-          <p>Call or WhatsApp <a href="tel:+529841670697">+52 984 167 0697</a></p>
-          <p>Office hours: Monday–Saturday, 8am–8pm local time</p>
+          <h3 data-i18n="contact.card.heading">Start a conversation</h3>
+          <p data-i18n="contact.card.email" data-i18n-attr="html">Email <a href="mailto:hello@beyondthereef.com">hello@beyondthereef.com</a></p>
+          <p data-i18n="contact.card.phone" data-i18n-attr="html">Call or WhatsApp <a href="tel:+529841670697">+52 984 167 0697</a></p>
+          <p data-i18n="contact.card.hours">Office hours: Monday–Saturday, 8am–8pm local time</p>
         </article>
-        <form class="contact-card contact-form" aria-label="Contact Beyond the Reef">
+        <form class="contact-card contact-form" aria-label="Contact Beyond the Reef" data-i18n="contact.form.aria" data-i18n-attr="aria-label">
           <div class="field">
-            <label for="name">Full name</label>
-            <input id="name" type="text" name="name" placeholder="Alex Morgan" required />
+            <label for="name" data-i18n="contact.form.nameLabel">Full name</label>
+            <input id="name" type="text" name="name" placeholder="Alex Morgan" required data-i18n="contact.form.namePlaceholder" data-i18n-attr="placeholder" />
           </div>
           <div class="field">
-            <label for="email">Email</label>
-            <input id="email" type="email" name="email" placeholder="you@example.com" required />
+            <label for="email" data-i18n="contact.form.emailLabel">Email</label>
+            <input id="email" type="email" name="email" placeholder="you@example.com" required data-i18n="contact.form.emailPlaceholder" data-i18n-attr="placeholder" />
           </div>
           <div class="field">
-            <label for="phone">Phone</label>
-            <input id="phone" type="tel" name="phone" placeholder="Optional" />
+            <label for="phone" data-i18n="contact.form.phoneLabel">Phone</label>
+            <input id="phone" type="tel" name="phone" placeholder="Optional" data-i18n="contact.form.phonePlaceholder" data-i18n-attr="placeholder" />
           </div>
           <div class="field">
-            <label for="travel-dates">Ideal travel window</label>
-            <input id="travel-dates" type="text" name="dates" placeholder="June 10 – 18, flexible" />
+            <label for="travel-dates" data-i18n="contact.form.datesLabel">Ideal travel window</label>
+            <input id="travel-dates" type="text" name="dates" placeholder="June 10 – 18, flexible" data-i18n="contact.form.datesPlaceholder" data-i18n-attr="placeholder" />
           </div>
           <div class="field">
-            <label for="message">Tell us about your dream tour</label>
-            <textarea id="message" name="message" placeholder="We want to celebrate with a sunset vow renewal..." required></textarea>
+            <label for="message" data-i18n="contact.form.messageLabel">Tell us about your dream tour</label>
+            <textarea
+              id="message"
+              name="message"
+              placeholder="We want to celebrate with a sunset vow renewal..."
+              required
+              data-i18n="contact.form.messagePlaceholder"
+              data-i18n-attr="placeholder"
+            ></textarea>
           </div>
-          <button class="button button--primary" type="submit">Send message</button>
-          <p class="text-small" style="color: var(--text-muted); margin: 0;">We respect your privacy and will never spam.</p>
+          <button class="button button--primary" type="submit" data-i18n="contact.form.submit">Send message</button>
+          <p class="text-small" style="color: var(--text-muted); margin: 0;" data-i18n="contact.form.disclaimer">We respect your privacy and will never spam.</p>
         </form>
       </div>
     </section>
   </main>
 
   <footer class="site-footer">
-    <p>&copy; <span id="current-year"></span> Beyond the Reef Adventures. All rights reserved.</p>
+    <p>
+      &copy; <span id="current-year"></span>
+      <span data-i18n="footer.rights">Beyond the Reef Adventures. All rights reserved.</span>
+    </p>
   </footer>
 
-  <div class="floating-contact" role="complementary" aria-label="Quick contact options">
+  <div
+    class="floating-contact"
+    role="complementary"
+    aria-label="Quick contact options"
+    data-i18n="floatingContact.aria"
+    data-i18n-attr="aria-label"
+  >
     <a
       class="floating-contact__link floating-contact__link--whatsapp"
       href="https://wa.me/529841670697"
       target="_blank"
       rel="noopener noreferrer"
       aria-label="Chat on WhatsApp"
+      data-i18n="floatingContact.whatsappAria"
+      data-i18n-attr="aria-label"
     >
       <span class="floating-contact__icon" aria-hidden="true">
         <svg viewBox="0 0 24 24" role="presentation" focusable="false" stroke-linecap="round" stroke-linejoin="round">
@@ -115,6 +134,8 @@
       target="_blank"
       rel="noopener noreferrer"
       aria-label="Open Instagram"
+      data-i18n="floatingContact.instagramAria"
+      data-i18n-attr="aria-label"
     >
       <span class="floating-contact__icon" aria-hidden="true">
         <svg viewBox="0 0 24 24" role="presentation" focusable="false" stroke-linecap="round" stroke-linejoin="round">

--- a/index.html
+++ b/index.html
@@ -3,15 +3,15 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Beyond the Reef Adventures</title>
+  <title data-i18n="page.title">Beyond the Reef Adventures</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="style.css" />
 </head>
-<body>
+<body data-page="home">
   <header class="site-header">
-    <nav class="nav" aria-label="Primary">
+    <nav class="nav" aria-label="Primary" data-i18n="nav.primary" data-i18n-attr="aria-label">
       <a class="nav__logo" href="index.html" aria-label="Beyond the Reef Mexico">
         <span class="nav__logo-icon" aria-hidden="true">
           <img src="assets/logo.svg" alt="" />
@@ -22,40 +22,57 @@
         </span>
       </a>
       <button class="nav__toggle" type="button" aria-expanded="false" aria-controls="primary-navigation" data-nav-toggle>
-        <span class="sr-only">Toggle navigation</span>
+        <span class="sr-only" data-i18n="nav.toggle">Toggle navigation</span>
         <span></span>
         <span></span>
         <span></span>
       </button>
       <ul class="nav__links" id="primary-navigation">
-        <li><a href="index.html" aria-current="page">Home</a></li>
-        <li><a href="build-your-tours.html">Create Your Experience</a></li>
-        <li><a href="review.html">Reviews</a></li>
-        <li><a href="our-story.html">Our Story</a></li>
-        <li><a href="contact.html">Contact</a></li>
+        <li><a href="index.html" aria-current="page" data-i18n="nav.home">Home</a></li>
+        <li><a href="build-your-tours.html" data-i18n="nav.create">Create Your Experience</a></li>
+        <li><a href="review.html" data-i18n="nav.reviews">Reviews</a></li>
+        <li><a href="our-story.html" data-i18n="nav.story">Our Story</a></li>
+        <li><a href="contact.html" data-i18n="nav.contact">Contact</a></li>
       </ul>
-      <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">Dark mode</button>
+      <button class="nav__control language-toggle" type="button" data-language-toggle aria-pressed="false">Español 🇲🇽</button>
+      <button class="nav__control theme-toggle" type="button" data-theme-toggle aria-pressed="false">Dark mode</button>
     </nav>
   </header>
 
   <main>
-    <section class="hero-slider" aria-label="Featured Experiences">
+    <section class="hero-slider" aria-label="Featured Experiences" data-i18n="home.hero.aria" data-i18n-attr="aria-label">
       <div class="hero-slider__content">
-        <h2>Pure adrenaline. Untamed nature. Your story in the making.</h2>
-        <p>Not just a day out — this is freedom unleashed.
-          Swim with turtles, dive into cenotes, race across lagoons, and explore ancient Mayan ruins.
-           No crowds. No limits. Just raw adventure carved into the heart of the Riviera Maya.
-
-           Your rules. Your pace. Your unforgettable.
-           This isn’t tourism.
-           This is Beyond the Reef.</p>
-        <a class="button button--primary" href="build-your-tours.html">Create Your Experience</a>
+        <h2 data-i18n="home.hero.heading">Pure adrenaline. Untamed nature. Your story in the making.</h2>
+        <p data-i18n="home.hero.description">
+          Not just a day out — this is freedom unleashed. Swim with turtles, dive into cenotes, race across lagoons, and explore
+          ancient Mayan ruins. No crowds. No limits. Just raw adventure carved into the heart of the Riviera Maya. Your rules.
+          Your pace. Your unforgettable. This isn’t tourism. This is Beyond the Reef.
+        </p>
+        <a class="button button--primary" href="build-your-tours.html" data-i18n="nav.create">Create Your Experience</a>
       </div>
       <div class="hero-slider__controls" aria-hidden="true">
-        <button class="hero-slider__arrow" type="button" data-slide="prev" aria-label="Previous slide">❮</button>
-        <button class="hero-slider__arrow" type="button" data-slide="next" aria-label="Next slide">❯</button>
+        <button
+          class="hero-slider__arrow"
+          type="button"
+          data-slide="prev"
+          aria-label="Previous slide"
+          data-i18n="home.hero.previous"
+          data-i18n-attr="aria-label"
+        >
+          ❮
+        </button>
+        <button
+          class="hero-slider__arrow"
+          type="button"
+          data-slide="next"
+          aria-label="Next slide"
+          data-i18n="home.hero.next"
+          data-i18n-attr="aria-label"
+        >
+          ❯
+        </button>
       </div>
-      <div class="hero-slider__dots" role="tablist" aria-label="Featured slides"></div>
+      <div class="hero-slider__dots" role="tablist" aria-label="Featured slides" data-i18n="home.hero.dots" data-i18n-attr="aria-label"></div>
       <div class="hero-slider__track">
         <article class="hero-slide is-active" aria-hidden="false">
           <video
@@ -107,7 +124,7 @@
     <section class="section section--difference" aria-labelledby="difference-heading">
       <div class="difference">
         <div class="section__intro difference__intro">
-          <h2 id="difference-heading">Experience the Difference</h2>
+          <h2 id="difference-heading" data-i18n="home.difference.heading">Experience the Difference</h2>
         </div>
         <div class="difference__grid" role="list">
           <article class="card difference-item" role="listitem">
@@ -118,8 +135,8 @@
                 <circle cx="12" cy="12.5" r="3.5" />
               </svg>
             </span>
-            <h3>Captured</h3>
-            <p>Complimentary Photography on Every Tour</p>
+            <h3 data-i18n="home.difference.captured.title">Captured</h3>
+            <p data-i18n="home.difference.captured.copy">Complimentary Photography on Every Tour</p>
           </article>
           <article class="card difference-item" role="listitem">
             <span class="difference-item__icon" aria-hidden="true">
@@ -129,8 +146,8 @@
                 <path d="m14.75 9.75 2.75 2.25-2.75 2.25" />
               </svg>
             </span>
-            <h3>Set the Pace</h3>
-            <p>Choose your start time, skip pickups, set your own schedule</p>
+            <h3 data-i18n="home.difference.pace.title">Set the Pace</h3>
+            <p data-i18n="home.difference.pace.copy">Choose your start time, skip pickups, set your own schedule</p>
           </article>
           <article class="card difference-item" role="listitem">
             <span class="difference-item__icon" aria-hidden="true">
@@ -146,8 +163,8 @@
                 <path d="m8.5 15.5-1.75 1.75" />
               </svg>
             </span>
-            <h3>Your Journey</h3>
-            <p>Snorkel, explore, taste, relax — the choice is yours</p>
+            <h3 data-i18n="home.difference.journey.title">Your Journey</h3>
+            <p data-i18n="home.difference.journey.copy">Snorkel, explore, taste, relax — the choice is yours</p>
           </article>
           <article class="card difference-item" role="listitem">
             <span class="difference-item__icon" aria-hidden="true">
@@ -156,8 +173,8 @@
                 <path d="m9.25 12.5 2.25 2.25 3.25-3.25" />
               </svg>
             </span>
-            <h3>No Surprises</h3>
-            <p>No hidden costs, No extra charges, Just adventure</p>
+            <h3 data-i18n="home.difference.surprises.title">No Surprises</h3>
+            <p data-i18n="home.difference.surprises.copy">No hidden costs, No extra charges, Just adventure</p>
           </article>
           <article class="card difference-item" role="listitem">
             <span class="difference-item__icon" aria-hidden="true">
@@ -166,8 +183,8 @@
                 <path d="M8.5 13.4 7.25 20l4.75-1.8L16.75 20 15.5 13.4" />
               </svg>
             </span>
-            <h3>Excellence</h3>
-            <p>We don’t claim it — our guests do. Five stars, every time.</p>
+            <h3 data-i18n="home.difference.excellence.title">Excellence</h3>
+            <p data-i18n="home.difference.excellence.copy">We don’t claim it — our guests do. Five stars, every time.</p>
           </article>
         </div>
       </div>
@@ -175,53 +192,64 @@
 
     <section class="section" id="tour-builder">
       <div class="section__intro">
-        <p class="eyebrow">Build your tour</p>
-        <h2>Design a custom itinerary in minutes</h2>
-        <p>Create a bespoke adventure by mixing activities, dining, and relaxation. Add each idea to your itinerary and we will weave it into a seamless journey.</p>
+        <p class="eyebrow" data-i18n="home.builder.eyebrow">Build your tour</p>
+        <h2 data-i18n="home.builder.heading">Design a custom itinerary in minutes</h2>
+        <p data-i18n="home.builder.copy">
+          Create a bespoke adventure by mixing activities, dining, and relaxation. Add each idea to your itinerary and we will weave it into a seamless journey.
+        </p>
       </div>
       <div class="tour-builder">
-        <form class="card" id="tour-builder-form" aria-label="Add an activity to your custom tour">
+        <form class="card" id="tour-builder-form" aria-label="Add an activity to your custom tour" data-i18n="home.builder.formAria" data-i18n-attr="aria-label">
           <div class="field">
-            <label for="activity-name">Activity name</label>
-            <input id="activity-name" name="activity" type="text" placeholder="Night snorkel" required />
+            <label for="activity-name" data-i18n="home.builder.activityLabel">Activity name</label>
+            <input id="activity-name" name="activity" type="text" placeholder="Night snorkel" required data-i18n="home.builder.activityPlaceholder" data-i18n-attr="placeholder" />
           </div>
           <div class="field">
-            <label for="activity-date">Preferred date</label>
+            <label for="activity-date" data-i18n="home.builder.dateLabel">Preferred date</label>
             <input id="activity-date" name="date" type="date" />
           </div>
           <div class="field">
-            <label for="activity-notes">Special touches</label>
-            <textarea id="activity-notes" name="notes" rows="3" placeholder="Add a sunset picnic with locally sourced fruit."></textarea>
+            <label for="activity-notes" data-i18n="home.builder.notesLabel">Special touches</label>
+            <textarea
+              id="activity-notes"
+              name="notes"
+              rows="3"
+              placeholder="Add a sunset picnic with locally sourced fruit."
+              data-i18n="home.builder.notesPlaceholder"
+              data-i18n-attr="placeholder"
+            ></textarea>
           </div>
-          <button class="button button--primary" type="submit">Add to itinerary</button>
+          <button class="button button--primary" type="submit" data-i18n="home.builder.add">Add to itinerary</button>
         </form>
         <div class="card tour-itinerary" aria-live="polite">
-          <h3>Your custom itinerary</h3>
+          <h3 data-i18n="home.builder.listHeading">Your custom itinerary</h3>
           <ul id="itinerary-list" class="itinerary-list">
-            <li class="itinerary-list__placeholder">Your ideas will appear here. Add the first one to begin crafting the perfect tour.</li>
+            <li class="itinerary-list__placeholder" data-i18n="home.builder.placeholder">
+              Your ideas will appear here. Add the first one to begin crafting the perfect tour.
+            </li>
           </ul>
-          <button class="button button--ghost" type="button" id="clear-itinerary">Clear itinerary</button>
+          <button class="button button--ghost" type="button" id="clear-itinerary" data-i18n="home.builder.clear">Clear itinerary</button>
         </div>
       </div>
     </section>
 
     <section class="section section--accent">
       <div class="section__intro">
-        <p class="eyebrow">Why travelers love us</p>
-        <h2>Concierge-level planning at lightning speed</h2>
+        <p class="eyebrow" data-i18n="home.accent.eyebrow">Why travelers love us</p>
+        <h2 data-i18n="home.accent.heading">Concierge-level planning at lightning speed</h2>
       </div>
       <div class="grid grid--features">
         <article class="card feature-card">
-          <h3>Crafted by locals</h3>
-          <p>Our specialists live on the islands year round, curating insider-only moments you cannot find on a brochure.</p>
+          <h3 data-i18n="home.accent.locals.title">Crafted by locals</h3>
+          <p data-i18n="home.accent.locals.copy">Our specialists live on the islands year round, curating insider-only moments you cannot find on a brochure.</p>
         </article>
         <article class="card feature-card">
-          <h3>Real-time collaboration</h3>
-          <p>Invite friends or family to add ideas to your itinerary and watch it come to life instantly.</p>
+          <h3 data-i18n="home.accent.collab.title">Real-time collaboration</h3>
+          <p data-i18n="home.accent.collab.copy">Invite friends or family to add ideas to your itinerary and watch it come to life instantly.</p>
         </article>
         <article class="card feature-card">
-          <h3>Seamless execution</h3>
-          <p>From airport transfer to last toast, your dedicated host orchestrates every detail while you unwind.</p>
+          <h3 data-i18n="home.accent.execution.title">Seamless execution</h3>
+          <p data-i18n="home.accent.execution.copy">From airport transfer to last toast, your dedicated host orchestrates every detail while you unwind.</p>
         </article>
       </div>
     </section>
@@ -229,25 +257,36 @@
     <section class="section">
       <div class="cta">
         <div>
-          <h2>Ready to feel the sea breeze?</h2>
-          <p>Answer a few questions and we will send a bespoke proposal within 24 hours.</p>
+          <h2 data-i18n="home.cta.heading">Ready to feel the sea breeze?</h2>
+          <p data-i18n="home.cta.copy">Answer a few questions and we will send a bespoke proposal within 24 hours.</p>
         </div>
-        <a class="button button--primary" href="contact.html">Plan my escape</a>
+        <a class="button button--primary" href="contact.html" data-i18n="home.cta.button">Plan my escape</a>
       </div>
     </section>
   </main>
 
   <footer class="site-footer">
-    <p>&copy; <span id="current-year"></span> Beyond the Reef Adventures. All rights reserved.</p>
+    <p>
+      &copy; <span id="current-year"></span>
+      <span data-i18n="footer.rights">Beyond the Reef Adventures. All rights reserved.</span>
+    </p>
   </footer>
 
-  <div class="floating-contact" role="complementary" aria-label="Quick contact options">
+  <div
+    class="floating-contact"
+    role="complementary"
+    aria-label="Quick contact options"
+    data-i18n="floatingContact.aria"
+    data-i18n-attr="aria-label"
+  >
     <a
       class="floating-contact__link floating-contact__link--whatsapp"
       href="https://wa.me/529841670697"
       target="_blank"
       rel="noopener noreferrer"
       aria-label="Chat on WhatsApp"
+      data-i18n="floatingContact.whatsappAria"
+      data-i18n-attr="aria-label"
     >
       <span class="floating-contact__icon" aria-hidden="true">
         <svg viewBox="0 0 24 24" role="presentation" focusable="false" stroke-linecap="round" stroke-linejoin="round">
@@ -268,6 +307,8 @@
       target="_blank"
       rel="noopener noreferrer"
       aria-label="Open Instagram"
+      data-i18n="floatingContact.instagramAria"
+      data-i18n-attr="aria-label"
     >
       <span class="floating-contact__icon" aria-hidden="true">
         <svg viewBox="0 0 24 24" role="presentation" focusable="false" stroke-linecap="round" stroke-linejoin="round">

--- a/our-story.html
+++ b/our-story.html
@@ -3,15 +3,15 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Our Story | Beyond the Reef Adventures</title>
+  <title data-i18n="page.title">Our Story | Beyond the Reef Adventures</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="style.css" />
 </head>
-<body>
+<body data-page="story">
   <header class="site-header">
-    <nav class="nav" aria-label="Primary">
+    <nav class="nav" aria-label="Primary" data-i18n="nav.primary" data-i18n-attr="aria-label">
       <a class="nav__logo" href="index.html" aria-label="Beyond the Reef Mexico">
         <span class="nav__logo-icon" aria-hidden="true">
           <svg viewBox="0 0 148 96" role="presentation" focusable="false">
@@ -26,19 +26,20 @@
         </span>
       </a>
       <button class="nav__toggle" type="button" aria-expanded="false" aria-controls="primary-navigation" data-nav-toggle>
-        <span class="sr-only">Toggle navigation</span>
+        <span class="sr-only" data-i18n="nav.toggle">Toggle navigation</span>
         <span></span>
         <span></span>
         <span></span>
       </button>
       <ul class="nav__links" id="primary-navigation">
-        <li><a href="index.html">Home</a></li>
-        <li><a href="build-your-tours.html">Create Your Experience</a></li>
-        <li><a href="review.html">Reviews</a></li>
-        <li><a href="our-story.html" aria-current="page">Our Story</a></li>
-        <li><a href="contact.html">Contact</a></li>
+        <li><a href="index.html" data-i18n="nav.home">Home</a></li>
+        <li><a href="build-your-tours.html" data-i18n="nav.create">Create Your Experience</a></li>
+        <li><a href="review.html" data-i18n="nav.reviews">Reviews</a></li>
+        <li><a href="our-story.html" aria-current="page" data-i18n="nav.story">Our Story</a></li>
+        <li><a href="contact.html" data-i18n="nav.contact">Contact</a></li>
       </ul>
-      <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">Dark mode</button>
+      <button class="nav__control language-toggle" type="button" data-language-toggle aria-pressed="false">Español 🇲🇽</button>
+      <button class="nav__control theme-toggle" type="button" data-theme-toggle aria-pressed="false">Dark mode</button>
     </nav>
   </header>
 
@@ -46,60 +47,71 @@
     <section class="page-hero">
       <img class="page-hero__background" src="https://images.unsplash.com/photo-1526772662000-3f88f10405ff?auto=format&fit=crop&w=1600&q=80" alt="Ocean waves crashing on rocks" />
       <div>
-        <p class="eyebrow">Our story</p>
-        <h1>Born from a love of the sea and storytelling</h1>
-        <p>We believe every traveler deserves a tailor-made narrative—crafted by locals, powered by technology, and infused with genuine hospitality.</p>
+        <p class="eyebrow" data-i18n="story.hero.eyebrow">Our story</p>
+        <h1 data-i18n="story.hero.heading">Born from a love of the sea and storytelling</h1>
+        <p data-i18n="story.hero.copy">We believe every traveler deserves a tailor-made narrative—crafted by locals, powered by technology, and infused with genuine hospitality.</p>
       </div>
     </section>
 
     <section class="page-section">
-      <h2>Meet the crew</h2>
+      <h2 data-i18n="story.crew.heading">Meet the crew</h2>
       <div class="page-grid">
         <article class="card">
-          <h3>Lila Reyes — Founder</h3>
-          <p>A marine biologist turned travel designer, Lila launched Beyond the Reef to share hidden reefs and island communities with respectful explorers.</p>
+          <h3 data-i18n="story.crew.lila.title">Lila Reyes — Founder</h3>
+          <p data-i18n="story.crew.lila.copy">A marine biologist turned travel designer, Lila launched Beyond the Reef to share hidden reefs and island communities with respectful explorers.</p>
         </article>
         <article class="card">
-          <h3>Makai Thompson — Experience Architect</h3>
-          <p>Raised between three islands, Makai weaves cultural rituals, local artisans, and signature flavors into each itinerary.</p>
+          <h3 data-i18n="story.crew.makai.title">Makai Thompson — Experience Architect</h3>
+          <p data-i18n="story.crew.makai.copy">Raised between three islands, Makai weaves cultural rituals, local artisans, and signature flavors into each itinerary.</p>
         </article>
         <article class="card">
-          <h3>Sami Chen — Technology Lead</h3>
-          <p>Sami built our collaborative planning platform with real-time availability checks and concierge messaging that feels like texting a friend.</p>
+          <h3 data-i18n="story.crew.sami.title">Sami Chen — Technology Lead</h3>
+          <p data-i18n="story.crew.sami.copy">Sami built our collaborative planning platform with real-time availability checks and concierge messaging that feels like texting a friend.</p>
         </article>
       </div>
     </section>
 
     <section class="page-section">
-      <h2>What we stand for</h2>
+      <h2 data-i18n="story.values.heading">What we stand for</h2>
       <div class="grid">
         <article class="card">
-          <h3>Regenerative travel</h3>
-          <p>We partner with community-led conservation projects and donate a portion of every itinerary to reef restoration.</p>
+          <h3 data-i18n="story.values.regen.title">Regenerative travel</h3>
+          <p data-i18n="story.values.regen.copy">We partner with community-led conservation projects and donate a portion of every itinerary to reef restoration.</p>
         </article>
         <article class="card">
-          <h3>Hospitality with heart</h3>
-          <p>Your hosts welcome you like family, preparing meaningful surprises and thoughtful touches along the way.</p>
+          <h3 data-i18n="story.values.hospitality.title">Hospitality with heart</h3>
+          <p data-i18n="story.values.hospitality.copy">Your hosts welcome you like family, preparing meaningful surprises and thoughtful touches along the way.</p>
         </article>
         <article class="card">
-          <h3>Technology that disappears</h3>
-          <p>The planning tools are powerful, yet effortless, so you stay focused on excitement rather than logistics.</p>
+          <h3 data-i18n="story.values.tech.title">Technology that disappears</h3>
+          <p data-i18n="story.values.tech.copy">The planning tools are powerful, yet effortless, so you stay focused on excitement rather than logistics.</p>
         </article>
       </div>
     </section>
   </main>
 
   <footer class="site-footer">
-    <p>&copy; <span id="current-year"></span> Beyond the Reef Adventures. All rights reserved.</p>
+    <p>
+      &copy; <span id="current-year"></span>
+      <span data-i18n="footer.rights">Beyond the Reef Adventures. All rights reserved.</span>
+    </p>
   </footer>
 
-  <div class="floating-contact" role="complementary" aria-label="Quick contact options">
+  <div
+    class="floating-contact"
+    role="complementary"
+    aria-label="Quick contact options"
+    data-i18n="floatingContact.aria"
+    data-i18n-attr="aria-label"
+  >
     <a
       class="floating-contact__link floating-contact__link--whatsapp"
       href="https://wa.me/529841670697"
       target="_blank"
       rel="noopener noreferrer"
       aria-label="Chat on WhatsApp"
+      data-i18n="floatingContact.whatsappAria"
+      data-i18n-attr="aria-label"
     >
       <span class="floating-contact__icon" aria-hidden="true">
         <svg viewBox="0 0 24 24" role="presentation" focusable="false" stroke-linecap="round" stroke-linejoin="round">
@@ -120,6 +132,8 @@
       target="_blank"
       rel="noopener noreferrer"
       aria-label="Open Instagram"
+      data-i18n="floatingContact.instagramAria"
+      data-i18n-attr="aria-label"
     >
       <span class="floating-contact__icon" aria-hidden="true">
         <svg viewBox="0 0 24 24" role="presentation" focusable="false" stroke-linecap="round" stroke-linejoin="round">

--- a/review.html
+++ b/review.html
@@ -3,15 +3,15 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Guest Reviews | Beyond the Reef Adventures</title>
+  <title data-i18n="page.title">Guest Reviews | Beyond the Reef Adventures</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="style.css" />
 </head>
-<body>
+<body data-page="reviews">
   <header class="site-header">
-    <nav class="nav" aria-label="Primary">
+    <nav class="nav" aria-label="Primary" data-i18n="nav.primary" data-i18n-attr="aria-label">
       <a class="nav__logo" href="index.html" aria-label="Beyond the Reef Mexico">
         <span class="nav__logo-icon" aria-hidden="true">
           <svg viewBox="0 0 148 96" role="presentation" focusable="false">
@@ -26,19 +26,20 @@
         </span>
       </a>
       <button class="nav__toggle" type="button" aria-expanded="false" aria-controls="primary-navigation" data-nav-toggle>
-        <span class="sr-only">Toggle navigation</span>
+        <span class="sr-only" data-i18n="nav.toggle">Toggle navigation</span>
         <span></span>
         <span></span>
         <span></span>
       </button>
       <ul class="nav__links" id="primary-navigation">
-        <li><a href="index.html">Home</a></li>
-        <li><a href="build-your-tours.html">Create Your Experience</a></li>
-        <li><a href="review.html" aria-current="page">Reviews</a></li>
-        <li><a href="our-story.html">Our Story</a></li>
-        <li><a href="contact.html">Contact</a></li>
+        <li><a href="index.html" data-i18n="nav.home">Home</a></li>
+        <li><a href="build-your-tours.html" data-i18n="nav.create">Create Your Experience</a></li>
+        <li><a href="review.html" aria-current="page" data-i18n="nav.reviews">Reviews</a></li>
+        <li><a href="our-story.html" data-i18n="nav.story">Our Story</a></li>
+        <li><a href="contact.html" data-i18n="nav.contact">Contact</a></li>
       </ul>
-      <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">Dark mode</button>
+      <button class="nav__control language-toggle" type="button" data-language-toggle aria-pressed="false">Español 🇲🇽</button>
+      <button class="nav__control theme-toggle" type="button" data-theme-toggle aria-pressed="false">Dark mode</button>
     </nav>
   </header>
 
@@ -46,47 +47,61 @@
     <section class="page-hero">
       <img class="page-hero__background" src="https://images.unsplash.com/photo-1473625247510-8ceb1760943f?auto=format&fit=crop&w=1600&q=80" alt="Happy travelers on a boat" />
       <div>
-        <p class="eyebrow">Guest love letters</p>
-        <h1>Stories from travelers who went beyond</h1>
-        <p>Hear how custom-crafted journeys and thoughtful touches turned bucket-list dreams into effortless escapes.</p>
+        <p class="eyebrow" data-i18n="reviews.hero.eyebrow">Guest love letters</p>
+        <h1 data-i18n="reviews.hero.heading">Stories from travelers who went beyond</h1>
+        <p data-i18n="reviews.hero.copy">Hear how custom-crafted journeys and thoughtful touches turned bucket-list dreams into effortless escapes.</p>
       </div>
     </section>
 
     <section class="page-section">
-      <h2>Featured reviews</h2>
+      <h2 data-i18n="reviews.featured.heading">Featured reviews</h2>
       <div class="review-list">
         <article class="review-card">
-          <h3>“They thought of every detail.”</h3>
-          <p>“From the midnight manta ray swim to the surprise anniversary dinner on a sandbar, the Beyond the Reef team went above and beyond. We never looked at our watches once.” — <strong>Cam &amp; Jordan</strong></p>
+          <h3 data-i18n="reviews.featured.one.title">“They thought of every detail.”</h3>
+          <p data-i18n="reviews.featured.one.copy" data-i18n-attr="html">“From the midnight manta ray swim to the surprise anniversary dinner on a sandbar, the Beyond the Reef team went above and beyond. We never looked at our watches once.” — <strong>Cam &amp; Jordan</strong></p>
         </article>
         <article class="review-card">
-          <h3>“Planning was actually fun.”</h3>
-          <p>“We built the itinerary together during a video call and could see availability update live. Their concierge secured a private guide for my dad so he could explore at his own pace.” — <strong>Riya</strong></p>
+          <h3 data-i18n="reviews.featured.two.title">“Planning was actually fun.”</h3>
+          <p data-i18n="reviews.featured.two.copy" data-i18n-attr="html">“We built the itinerary together during a video call and could see availability update live. Their concierge secured a private guide for my dad so he could explore at his own pace.” — <strong>Riya</strong></p>
         </article>
         <article class="review-card">
-          <h3>“Our friends are still raving.”</h3>
-          <p>“The group chat was blowing up with ideas. The Beyond the Reef planner kept everything organized and even added mixology classes based on our Spotify playlist.” — <strong>Diego &amp; crew</strong></p>
+          <h3 data-i18n="reviews.featured.three.title">“Our friends are still raving.”</h3>
+          <p data-i18n="reviews.featured.three.copy" data-i18n-attr="html">“The group chat was blowing up with ideas. The Beyond the Reef planner kept everything organized and even added mixology classes based on our Spotify playlist.” — <strong>Diego &amp; crew</strong></p>
         </article>
       </div>
     </section>
 
     <section class="page-section">
-      <h2>Share your experience</h2>
-      <p>Email <a href="mailto:hello@beyondthereef.com">hello@beyondthereef.com</a> with a highlight reel or tag us on social with <strong>#BeyondTheReef</strong> for a chance to be featured.</p>
+      <h2 data-i18n="reviews.share.heading">Share your experience</h2>
+      <p
+        data-i18n="reviews.share.copy"
+        data-i18n-attr="html"
+      >Email <a href="mailto:hello@beyondthereef.com">hello@beyondthereef.com</a> with a highlight reel or tag us on social with <strong>#BeyondTheReef</strong> for a chance to be featured.</p>
     </section>
   </main>
 
   <footer class="site-footer">
-    <p>&copy; <span id="current-year"></span> Beyond the Reef Adventures. All rights reserved.</p>
+    <p>
+      &copy; <span id="current-year"></span>
+      <span data-i18n="footer.rights">Beyond the Reef Adventures. All rights reserved.</span>
+    </p>
   </footer>
 
-  <div class="floating-contact" role="complementary" aria-label="Quick contact options">
+  <div
+    class="floating-contact"
+    role="complementary"
+    aria-label="Quick contact options"
+    data-i18n="floatingContact.aria"
+    data-i18n-attr="aria-label"
+  >
     <a
       class="floating-contact__link floating-contact__link--whatsapp"
       href="https://wa.me/529841670697"
       target="_blank"
       rel="noopener noreferrer"
       aria-label="Chat on WhatsApp"
+      data-i18n="floatingContact.whatsappAria"
+      data-i18n-attr="aria-label"
     >
       <span class="floating-contact__icon" aria-hidden="true">
         <svg viewBox="0 0 24 24" role="presentation" focusable="false" stroke-linecap="round" stroke-linejoin="round">
@@ -107,6 +122,8 @@
       target="_blank"
       rel="noopener noreferrer"
       aria-label="Open Instagram"
+      data-i18n="floatingContact.instagramAria"
+      data-i18n-attr="aria-label"
     >
       <span class="floating-contact__icon" aria-hidden="true">
         <svg viewBox="0 0 24 24" role="presentation" focusable="false" stroke-linecap="round" stroke-linejoin="round">

--- a/script.js
+++ b/script.js
@@ -1,12 +1,469 @@
+const translations = {
+  en: {
+    global: {
+      'nav.primary': 'Primary',
+      'nav.toggle': 'Toggle navigation',
+      'nav.home': 'Home',
+      'nav.create': 'Create Your Experience',
+      'nav.reviews': 'Reviews',
+      'nav.story': 'Our Story',
+      'nav.contact': 'Contact',
+      'footer.rights': 'Beyond the Reef Adventures. All rights reserved.',
+      'floatingContact.aria': 'Quick contact options',
+      'floatingContact.whatsappAria': 'Chat on WhatsApp',
+      'floatingContact.instagramAria': 'Open Instagram',
+      'themeToggle.dark': 'Dark mode',
+      'themeToggle.light': 'Light mode',
+      'heroSlider.goToSlide': 'Go to slide {{index}}',
+      'tourBuilder.remove': 'Remove'
+    },
+    home: {
+      'page.title': 'Beyond the Reef Adventures',
+      'home.hero.aria': 'Featured Experiences',
+      'home.hero.heading': 'Pure adrenaline. Untamed nature. Your story in the making.',
+      'home.hero.description':
+        'Not just a day out — this is freedom unleashed. Swim with turtles, dive into cenotes, race across lagoons, and explore ancient Mayan ruins. No crowds. No limits. Just raw adventure carved into the heart of the Riviera Maya. Your rules. Your pace. Your unforgettable. This isn’t tourism. This is Beyond the Reef.',
+      'home.hero.previous': 'Previous slide',
+      'home.hero.next': 'Next slide',
+      'home.hero.dots': 'Featured slides',
+      'home.difference.heading': 'Experience the Difference',
+      'home.difference.captured.title': 'Captured',
+      'home.difference.captured.copy': 'Complimentary Photography on Every Tour',
+      'home.difference.pace.title': 'Set the Pace',
+      'home.difference.pace.copy': 'Choose your start time, skip pickups, set your own schedule',
+      'home.difference.journey.title': 'Your Journey',
+      'home.difference.journey.copy': 'Snorkel, explore, taste, relax — the choice is yours',
+      'home.difference.surprises.title': 'No Surprises',
+      'home.difference.surprises.copy': 'No hidden costs, No extra charges, Just adventure',
+      'home.difference.excellence.title': 'Excellence',
+      'home.difference.excellence.copy': 'We don’t claim it — our guests do. Five stars, every time.',
+      'home.builder.eyebrow': 'Build your tour',
+      'home.builder.heading': 'Design a custom itinerary in minutes',
+      'home.builder.copy':
+        'Create a bespoke adventure by mixing activities, dining, and relaxation. Add each idea to your itinerary and we will weave it into a seamless journey.',
+      'home.builder.formAria': 'Add an activity to your custom tour',
+      'home.builder.activityLabel': 'Activity name',
+      'home.builder.activityPlaceholder': 'Night snorkel',
+      'home.builder.dateLabel': 'Preferred date',
+      'home.builder.notesLabel': 'Special touches',
+      'home.builder.notesPlaceholder': 'Add a sunset picnic with locally sourced fruit.',
+      'home.builder.add': 'Add to itinerary',
+      'home.builder.listHeading': 'Your custom itinerary',
+      'home.builder.placeholder':
+        'Your ideas will appear here. Add the first one to begin crafting the perfect tour.',
+      'home.builder.clear': 'Clear itinerary',
+      'home.accent.eyebrow': 'Why travelers love us',
+      'home.accent.heading': 'Concierge-level planning at lightning speed',
+      'home.accent.locals.title': 'Crafted by locals',
+      'home.accent.locals.copy':
+        'Our specialists live on the islands year round, curating insider-only moments you cannot find on a brochure.',
+      'home.accent.collab.title': 'Real-time collaboration',
+      'home.accent.collab.copy':
+        'Invite friends or family to add ideas to your itinerary and watch it come to life instantly.',
+      'home.accent.execution.title': 'Seamless execution',
+      'home.accent.execution.copy':
+        'From airport transfer to last toast, your dedicated host orchestrates every detail while you unwind.',
+      'home.cta.heading': 'Ready to feel the sea breeze?',
+      'home.cta.copy': 'Answer a few questions and we will send a bespoke proposal within 24 hours.',
+      'home.cta.button': 'Plan my escape'
+    },
+    tours: {
+      'page.title': 'Build Your Tours | Beyond the Reef Adventures',
+      'tours.hero.eyebrow': 'Build your tour',
+      'tours.hero.heading': 'Design experiences as unique as your crew',
+      'tours.hero.copy':
+        'Drag and drop curated activities, refine pacing, and invite your travel companions to collaborate in real time.',
+      'tours.grid.custom.title': 'Custom combinations',
+      'tours.grid.custom.copy':
+        'Mix scuba dives, culinary surprises, and remote hikes across islands. Our smart planner orchestrates logistics so you can focus on the fun.',
+      'tours.grid.pacing.title': 'Smart pacing',
+      'tours.grid.pacing.copy':
+        'We balance high-energy adventures with restorative interludes, ensuring every guest has time to recharge.',
+      'tours.grid.collab.title': 'Co-create instantly',
+      'tours.grid.collab.copy':
+        'Share a private link so your crew can vote, comment, or add new ideas. Our concierges can jump in live to fine-tune.',
+      'tours.steps.heading': 'How the custom builder works',
+      'tours.steps.one.title': 'Tell us about your dream',
+      'tours.steps.one.copy': 'Answer a few questions or import a mood board. We use your vibe to pre-select experiences.',
+      'tours.steps.two.title': 'Remix the plan',
+      'tours.steps.two.copy':
+        'Drag items between days, adjust timing, and add bespoke requests like photographers or private chefs.',
+      'tours.steps.three.title': 'Lock it in',
+      'tours.steps.three.copy':
+        'Collaborate with your concierge to finalize transfers, payments, and on-island support.'
+    },
+    reviews: {
+      'page.title': 'Guest Reviews | Beyond the Reef Adventures',
+      'reviews.hero.eyebrow': 'Guest love letters',
+      'reviews.hero.heading': 'Stories from travelers who went beyond',
+      'reviews.hero.copy':
+        'Hear how custom-crafted journeys and thoughtful touches turned bucket-list dreams into effortless escapes.',
+      'reviews.featured.heading': 'Featured reviews',
+      'reviews.featured.one.title': '“They thought of every detail.”',
+      'reviews.featured.one.copy':
+        '“From the midnight manta ray swim to the surprise anniversary dinner on a sandbar, the Beyond the Reef team went above and beyond. We never looked at our watches once.” — <strong>Cam &amp; Jordan</strong>',
+      'reviews.featured.two.title': '“Planning was actually fun.”',
+      'reviews.featured.two.copy':
+        '“We built the itinerary together during a video call and could see availability update live. Their concierge secured a private guide for my dad so he could explore at his own pace.” — <strong>Riya</strong>',
+      'reviews.featured.three.title': '“Our friends are still raving.”',
+      'reviews.featured.three.copy':
+        '“The group chat was blowing up with ideas. The Beyond the Reef planner kept everything organized and even added mixology classes based on our Spotify playlist.” — <strong>Diego &amp; crew</strong>',
+      'reviews.share.heading': 'Share your experience',
+      'reviews.share.copy':
+        'Email <a href="mailto:hello@beyondthereef.com">hello@beyondthereef.com</a> with a highlight reel or tag us on social with <strong>#BeyondTheReef</strong> for a chance to be featured.'
+    },
+    story: {
+      'page.title': 'Our Story | Beyond the Reef Adventures',
+      'story.hero.eyebrow': 'Our story',
+      'story.hero.heading': 'Born from a love of the sea and storytelling',
+      'story.hero.copy':
+        'We believe every traveler deserves a tailor-made narrative—crafted by locals, powered by technology, and infused with genuine hospitality.',
+      'story.crew.heading': 'Meet the crew',
+      'story.crew.lila.title': 'Lila Reyes — Founder',
+      'story.crew.lila.copy':
+        'A marine biologist turned travel designer, Lila launched Beyond the Reef to share hidden reefs and island communities with respectful explorers.',
+      'story.crew.makai.title': 'Makai Thompson — Experience Architect',
+      'story.crew.makai.copy':
+        'Raised between three islands, Makai weaves cultural rituals, local artisans, and signature flavors into each itinerary.',
+      'story.crew.sami.title': 'Sami Chen — Technology Lead',
+      'story.crew.sami.copy':
+        'Sami built our collaborative planning platform with real-time availability checks and concierge messaging that feels like texting a friend.',
+      'story.values.heading': 'What we stand for',
+      'story.values.regen.title': 'Regenerative travel',
+      'story.values.regen.copy':
+        'We partner with community-led conservation projects and donate a portion of every itinerary to reef restoration.',
+      'story.values.hospitality.title': 'Hospitality with heart',
+      'story.values.hospitality.copy':
+        'Your hosts welcome you like family, preparing meaningful surprises and thoughtful touches along the way.',
+      'story.values.tech.title': 'Technology that disappears',
+      'story.values.tech.copy':
+        'The planning tools are powerful, yet effortless, so you stay focused on excitement rather than logistics.'
+    },
+    contact: {
+      'page.title': 'Contact | Beyond the Reef Adventures',
+      'contact.hero.eyebrow': 'Say aloha',
+      'contact.hero.heading': 'Let’s bring your next adventure to life',
+      'contact.hero.copy':
+        'Share a few details and our concierge team will respond within one business day with ideas and availability.',
+      'contact.card.heading': 'Start a conversation',
+      'contact.card.email': 'Email <a href="mailto:hello@beyondthereef.com">hello@beyondthereef.com</a>',
+      'contact.card.phone': 'Call or WhatsApp <a href="tel:+529841670697">+52 984 167 0697</a>',
+      'contact.card.hours': 'Office hours: Monday–Saturday, 8am–8pm local time',
+      'contact.form.aria': 'Contact Beyond the Reef',
+      'contact.form.nameLabel': 'Full name',
+      'contact.form.namePlaceholder': 'Alex Morgan',
+      'contact.form.emailLabel': 'Email',
+      'contact.form.emailPlaceholder': 'you@example.com',
+      'contact.form.phoneLabel': 'Phone',
+      'contact.form.phonePlaceholder': 'Optional',
+      'contact.form.datesLabel': 'Ideal travel window',
+      'contact.form.datesPlaceholder': 'June 10 – 18, flexible',
+      'contact.form.messageLabel': 'Tell us about your dream tour',
+      'contact.form.messagePlaceholder': 'We want to celebrate with a sunset vow renewal...',
+      'contact.form.submit': 'Send message',
+      'contact.form.disclaimer': 'We respect your privacy and will never spam.'
+    }
+  },
+  es: {
+    global: {
+      'nav.primary': 'Principal',
+      'nav.toggle': 'Mostrar u ocultar la navegación',
+      'nav.home': 'Inicio',
+      'nav.create': 'Crea tu experiencia',
+      'nav.reviews': 'Reseñas',
+      'nav.story': 'Nuestra historia',
+      'nav.contact': 'Contacto',
+      'footer.rights': 'Beyond the Reef Adventures. Todos los derechos reservados.',
+      'floatingContact.aria': 'Opciones de contacto rápido',
+      'floatingContact.whatsappAria': 'Chatear en WhatsApp',
+      'floatingContact.instagramAria': 'Abrir Instagram',
+      'themeToggle.dark': 'Modo oscuro',
+      'themeToggle.light': 'Modo claro',
+      'heroSlider.goToSlide': 'Ir a la diapositiva {{index}}',
+      'tourBuilder.remove': 'Eliminar'
+    },
+    home: {
+      'page.title': 'Beyond the Reef Adventures',
+      'home.hero.aria': 'Experiencias destacadas',
+      'home.hero.heading': 'Pura adrenalina. Naturaleza indómita. Tu historia en marcha.',
+      'home.hero.description':
+        'No es solo una excursión: es libertad desatada. Nada con tortugas, sumérgete en cenotes, cruza lagunas a toda velocidad y explora antiguas ruinas mayas. Sin multitudes. Sin límites. Solo aventura pura en el corazón de la Riviera Maya. Tus reglas. Tu ritmo. Tu recuerdo inolvidable. Esto no es turismo. Esto es Beyond the Reef.',
+      'home.hero.previous': 'Diapositiva anterior',
+      'home.hero.next': 'Siguiente diapositiva',
+      'home.hero.dots': 'Diapositivas destacadas',
+      'home.difference.heading': 'Vive la diferencia',
+      'home.difference.captured.title': 'Capturado',
+      'home.difference.captured.copy': 'Fotografía incluida en cada tour',
+      'home.difference.pace.title': 'Marca el ritmo',
+      'home.difference.pace.copy': 'Elige tu horario, evita traslados y diseña tu propio itinerario',
+      'home.difference.journey.title': 'Tu travesía',
+      'home.difference.journey.copy': 'Snorkel, explorar, saborear o relajarte: tú decides',
+      'home.difference.surprises.title': 'Sin sorpresas',
+      'home.difference.surprises.copy': 'Sin costos ocultos, sin cargos extra, solo aventura',
+      'home.difference.excellence.title': 'Excelencia',
+      'home.difference.excellence.copy': 'No lo decimos nosotros: lo dicen nuestros huéspedes. Cinco estrellas siempre.',
+      'home.builder.eyebrow': 'Diseña tu tour',
+      'home.builder.heading': 'Crea un itinerario a medida en minutos',
+      'home.builder.copy':
+        'Diseña una aventura única combinando actividades, gastronomía y momentos de relajación. Agrega cada idea a tu itinerario y nosotros la convertiremos en un viaje perfecto.',
+      'home.builder.formAria': 'Agrega una actividad a tu tour personalizado',
+      'home.builder.activityLabel': 'Nombre de la actividad',
+      'home.builder.activityPlaceholder': 'Snorkel nocturno',
+      'home.builder.dateLabel': 'Fecha preferida',
+      'home.builder.notesLabel': 'Toques especiales',
+      'home.builder.notesPlaceholder': 'Incluye un picnic al atardecer con fruta local.',
+      'home.builder.add': 'Agregar al itinerario',
+      'home.builder.listHeading': 'Tu itinerario personalizado',
+      'home.builder.placeholder':
+        'Aquí aparecerán tus ideas. Agrega la primera para comenzar a crear el tour perfecto.',
+      'home.builder.clear': 'Borrar itinerario',
+      'home.accent.eyebrow': 'Por qué nos aman los viajeros',
+      'home.accent.heading': 'Planificación de concierge a toda velocidad',
+      'home.accent.locals.title': 'Creado por locales',
+      'home.accent.locals.copy':
+        'Nuestros especialistas viven en las islas todo el año y organizan momentos únicos que no encontrarás en un folleto.',
+      'home.accent.collab.title': 'Colaboración en tiempo real',
+      'home.accent.collab.copy':
+        'Invita a tus amigos o familia a sumar ideas y mira cómo el plan cobra vida al instante.',
+      'home.accent.execution.title': 'Ejecución impecable',
+      'home.accent.execution.copy':
+        'Desde el traslado hasta el último brindis, tu anfitrión se encarga de cada detalle mientras tú disfrutas.',
+      'home.cta.heading': '¿Listo para sentir la brisa marina?',
+      'home.cta.copy': 'Responde algunas preguntas y te enviaremos una propuesta personalizada en 24 horas.',
+      'home.cta.button': 'Planear mi escape'
+    },
+    tours: {
+      'page.title': 'Diseña tus tours | Beyond the Reef Adventures',
+      'tours.hero.eyebrow': 'Diseña tu tour',
+      'tours.hero.heading': 'Crea experiencias tan únicas como tu grupo',
+      'tours.hero.copy':
+        'Arrastra actividades seleccionadas, ajusta el ritmo e invita a tus acompañantes a colaborar en tiempo real.',
+      'tours.grid.custom.title': 'Combinaciones a medida',
+      'tours.grid.custom.copy':
+        'Mezcla buceo, sorpresas culinarias y caminatas remotas. Nuestro planificador inteligente coordina la logística para que solo te concentres en disfrutar.',
+      'tours.grid.pacing.title': 'Ritmo inteligente',
+      'tours.grid.pacing.copy':
+        'Equilibramos aventuras llenas de energía con momentos de descanso para que todos recarguen energías.',
+      'tours.grid.collab.title': 'Co-creación al instante',
+      'tours.grid.collab.copy':
+        'Comparte un enlace privado para que tu equipo vote, comente o agregue nuevas ideas. Nuestros concierges pueden sumarse en vivo para ajustarlo.',
+      'tours.steps.heading': 'Cómo funciona el constructor personalizado',
+      'tours.steps.one.title': 'Cuéntanos tu sueño',
+      'tours.steps.one.copy': 'Responde algunas preguntas o comparte un mood board. Usamos tu estilo para preseleccionar experiencias.',
+      'tours.steps.two.title': 'Reinventa el plan',
+      'tours.steps.two.copy':
+        'Reordena actividades por día, ajusta horarios y agrega peticiones especiales como fotógrafos o chefs privados.',
+      'tours.steps.three.title': 'Confírmalo todo',
+      'tours.steps.three.copy':
+        'Colabora con tu concierge para definir traslados, pagos y asistencia en destino.'
+    },
+    reviews: {
+      'page.title': 'Reseñas de huéspedes | Beyond the Reef Adventures',
+      'reviews.hero.eyebrow': 'Cartas de amor de nuestros huéspedes',
+      'reviews.hero.heading': 'Historias de viajeros que fueron más allá',
+      'reviews.hero.copy':
+        'Descubre cómo los viajes personalizados y los detalles cuidadosos convirtieron sueños en escapadas sin esfuerzo.',
+      'reviews.featured.heading': 'Reseñas destacadas',
+      'reviews.featured.one.title': '“Pensaron en cada detalle.”',
+      'reviews.featured.one.copy':
+        '“Desde el nado nocturno con mantarrayas hasta la cena sorpresa de aniversario en un banco de arena, el equipo de Beyond the Reef superó todas las expectativas. No miramos el reloj ni una sola vez.” — <strong>Cam &amp; Jordan</strong>',
+      'reviews.featured.two.title': '“Planear fue realmente divertido.”',
+      'reviews.featured.two.copy':
+        '“Construimos el itinerario juntos durante una videollamada y veíamos la disponibilidad en vivo. Su concierge consiguió un guía privado para mi papá para que explorara a su propio ritmo.” — <strong>Riya</strong>',
+      'reviews.featured.three.title': '“Nuestros amigos siguen hablando del viaje.”',
+      'reviews.featured.three.copy':
+        '“El chat del grupo no dejaba de llenarse de ideas. El planificador de Beyond the Reef mantuvo todo organizado e incluso añadió clases de mixología inspiradas en nuestra lista de Spotify.” — <strong>Diego &amp; crew</strong>',
+      'reviews.share.heading': 'Comparte tu experiencia',
+      'reviews.share.copy':
+        'Escríbenos a <a href="mailto:hello@beyondthereef.com">hello@beyondthereef.com</a> con los mejores momentos o etiquétanos en redes con <strong>#BeyondTheReef</strong> para tener la oportunidad de aparecer.'
+    },
+    story: {
+      'page.title': 'Nuestra historia | Beyond the Reef Adventures',
+      'story.hero.eyebrow': 'Nuestra historia',
+      'story.hero.heading': 'Nacimos del amor por el mar y por contar historias',
+      'story.hero.copy':
+        'Creemos que cada viajero merece una narrativa a la medida: creada por locales, impulsada por la tecnología e impregnada de hospitalidad genuina.',
+      'story.crew.heading': 'Conoce a la tripulación',
+      'story.crew.lila.title': 'Lila Reyes — Fundadora',
+      'story.crew.lila.copy':
+        'Bióloga marina convertida en diseñadora de viajes, Lila creó Beyond the Reef para compartir arrecifes ocultos y comunidades isleñas con exploradores respetuosos.',
+      'story.crew.makai.title': 'Makai Thompson — Arquitecto de Experiencias',
+      'story.crew.makai.copy':
+        'Criado entre tres islas, Makai teje rituales culturales, artesanos locales y sabores distintivos en cada itinerario.',
+      'story.crew.sami.title': 'Sami Chen — Líder de Tecnología',
+      'story.crew.sami.copy':
+        'Sami desarrolló nuestra plataforma colaborativa con disponibilidad en tiempo real y mensajes de concierge que se sienten como chatear con un amigo.',
+      'story.values.heading': 'Nuestros valores',
+      'story.values.regen.title': 'Viajes regenerativos',
+      'story.values.regen.copy':
+        'Nos aliamos con proyectos comunitarios de conservación y destinamos parte de cada itinerario a la restauración de arrecifes.',
+      'story.values.hospitality.title': 'Hospitalidad con corazón',
+      'story.values.hospitality.copy':
+        'Tus anfitriones te reciben como familia, preparando sorpresas significativas y detalles atentos durante todo el camino.',
+      'story.values.tech.title': 'Tecnología que se difumina',
+      'story.values.tech.copy':
+        'Nuestras herramientas de planificación son potentes pero sencillas, para que te enfoques en la emoción y no en la logística.'
+    },
+    contact: {
+      'page.title': 'Contacto | Beyond the Reef Adventures',
+      'contact.hero.eyebrow': 'Di aloha',
+      'contact.hero.heading': 'Hagamos realidad tu próxima aventura',
+      'contact.hero.copy':
+        'Comparte algunos detalles y nuestro equipo de concierge responderá en un día hábil con ideas y disponibilidad.',
+      'contact.card.heading': 'Inicia la conversación',
+      'contact.card.email': 'Escríbenos a <a href="mailto:hello@beyondthereef.com">hello@beyondthereef.com</a>',
+      'contact.card.phone': 'Llámanos o mándanos WhatsApp al <a href="tel:+529841670697">+52 984 167 0697</a>',
+      'contact.card.hours': 'Horario de oficina: lunes a sábado, 8 a.m. – 8 p.m. hora local',
+      'contact.form.aria': 'Contacta a Beyond the Reef',
+      'contact.form.nameLabel': 'Nombre completo',
+      'contact.form.namePlaceholder': 'Alex Morgan',
+      'contact.form.emailLabel': 'Correo electrónico',
+      'contact.form.emailPlaceholder': 'tu@ejemplo.com',
+      'contact.form.phoneLabel': 'Teléfono',
+      'contact.form.phonePlaceholder': 'Opcional',
+      'contact.form.datesLabel': 'Fechas ideales de viaje',
+      'contact.form.datesPlaceholder': '10 al 18 de junio, flexible',
+      'contact.form.messageLabel': 'Cuéntanos sobre tu tour soñado',
+      'contact.form.messagePlaceholder': 'Queremos celebrar con una renovación de votos al atardecer...',
+      'contact.form.submit': 'Enviar mensaje',
+      'contact.form.disclaimer': 'Respetamos tu privacidad y nunca enviaremos spam.'
+    }
+  }
+};
+
+const SUPPORTED_LANGUAGES = ['en', 'es'];
+
+function interpolate(template, replacements = {}) {
+  return template.replace(/\{\{(\w+)\}\}/g, (_, key) =>
+    Object.prototype.hasOwnProperty.call(replacements, key) ? String(replacements[key]) : ''
+  );
+}
+
+function createLanguageManager(pageKey) {
+  const LANGUAGE_STORAGE_KEY = 'preferred-language';
+  const storedLanguage = localStorage.getItem(LANGUAGE_STORAGE_KEY);
+  const documentLanguage = document.documentElement.lang;
+  let currentLanguage = SUPPORTED_LANGUAGES.includes(storedLanguage || '')
+    ? storedLanguage
+    : SUPPORTED_LANGUAGES.includes(documentLanguage)
+    ? documentLanguage
+    : 'en';
+  const listeners = new Set();
+
+  function getTranslationValue(lang, key) {
+    const languageSet = translations[lang];
+    if (!languageSet) return null;
+
+    if (languageSet.global && Object.prototype.hasOwnProperty.call(languageSet.global, key)) {
+      return languageSet.global[key];
+    }
+
+    if (pageKey && languageSet[pageKey] && Object.prototype.hasOwnProperty.call(languageSet[pageKey], key)) {
+      return languageSet[pageKey][key];
+    }
+
+    return null;
+  }
+
+  function translateDocument(lang) {
+    const languageSet = translations[lang];
+    if (!languageSet) return;
+
+    document.documentElement.lang = lang;
+
+    const groups = [];
+    if (languageSet.global) {
+      groups.push(languageSet.global);
+    }
+    if (pageKey && languageSet[pageKey]) {
+      groups.push(languageSet[pageKey]);
+    }
+
+    groups.forEach((group) => {
+      Object.entries(group).forEach(([key, value]) => {
+        const elements = document.querySelectorAll(`[data-i18n="${key}"]`);
+        if (!elements.length) return;
+
+        elements.forEach((element) => {
+          const attr = element.dataset.i18nAttr;
+          if (attr === 'html') {
+            element.innerHTML = value;
+          } else if (attr) {
+            element.setAttribute(attr, value);
+          } else {
+            element.textContent = value;
+          }
+        });
+      });
+    });
+  }
+
+  function notify(lang) {
+    listeners.forEach((callback) => {
+      try {
+        callback(lang);
+      } catch (error) {
+        console.error(error);
+      }
+    });
+  }
+
+  function applyLanguage(lang) {
+    translateDocument(lang);
+    notify(lang);
+  }
+
+  return {
+    init() {
+      applyLanguage(currentLanguage);
+    },
+    getLanguage() {
+      return currentLanguage;
+    },
+    setLanguage(lang) {
+      if (!SUPPORTED_LANGUAGES.includes(lang) || lang === currentLanguage) {
+        return;
+      }
+
+      currentLanguage = lang;
+      localStorage.setItem(LANGUAGE_STORAGE_KEY, lang);
+      applyLanguage(lang);
+    },
+    onChange(callback) {
+      if (typeof callback !== 'function') {
+        return () => {};
+      }
+
+      listeners.add(callback);
+      callback(currentLanguage);
+      return () => listeners.delete(callback);
+    },
+    translate(key, replacements = {}, lang = currentLanguage) {
+      const template = getTranslationValue(lang, key);
+      if (typeof template !== 'string') {
+        return '';
+      }
+
+      return interpolate(template, replacements);
+    }
+  };
+}
+
 (function () {
   const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)');
 
   document.addEventListener('DOMContentLoaded', () => {
+    const pageKey = document.body?.dataset.page || 'home';
+    const languageManager = createLanguageManager(pageKey);
+
     setupNavigation();
-    setupThemeToggle(prefersDark);
-    setupHeroSlider();
-    setupTourBuilder();
+    setupLanguageToggle(languageManager);
+    setupThemeToggle(prefersDark, languageManager);
+    setupHeroSlider(languageManager);
+    setupTourBuilder(languageManager);
     setCurrentYear();
+
+    languageManager.init();
   });
 })();
 
@@ -31,39 +488,62 @@ function setupNavigation() {
   });
 }
 
-function setupThemeToggle(prefersDark) {
+function setupLanguageToggle(languageManager) {
+  const toggle = document.querySelector('[data-language-toggle]');
+  if (!toggle) return;
+
+  const updateToggle = (lang) => {
+    const isSpanish = lang === 'es';
+    const nextLanguage = isSpanish ? 'en' : 'es';
+    toggle.textContent = nextLanguage === 'es' ? 'Español 🇲🇽' : 'English 🇺🇸';
+    toggle.setAttribute('aria-pressed', isSpanish ? 'true' : 'false');
+  };
+
+  toggle.addEventListener('click', () => {
+    const nextLanguage = languageManager.getLanguage() === 'en' ? 'es' : 'en';
+    languageManager.setLanguage(nextLanguage);
+  });
+
+  languageManager.onChange(updateToggle);
+}
+
+function setupThemeToggle(prefersDark, languageManager) {
   const toggle = document.querySelector('[data-theme-toggle]');
   if (!toggle) return;
 
   const storedTheme = localStorage.getItem('preferred-theme');
   const shouldUseDark = storedTheme ? storedTheme === 'dark' : prefersDark?.matches;
 
-  toggle.textContent = 'Dark mode';
-  toggle.setAttribute('aria-pressed', 'false');
-
   if (shouldUseDark) {
     document.body.classList.add('dark-mode');
-    toggle.textContent = 'Light mode';
-    toggle.setAttribute('aria-pressed', 'true');
   }
+  toggle.setAttribute('aria-pressed', shouldUseDark ? 'true' : 'false');
+
+  const updateLabel = (lang) => {
+    const isDark = document.body.classList.contains('dark-mode');
+    const key = isDark ? 'themeToggle.light' : 'themeToggle.dark';
+    toggle.textContent = languageManager.translate(key, {}, lang);
+  };
 
   toggle.addEventListener('click', () => {
     const isDark = document.body.classList.toggle('dark-mode');
-    toggle.textContent = isDark ? 'Light mode' : 'Dark mode';
     toggle.setAttribute('aria-pressed', isDark ? 'true' : 'false');
     localStorage.setItem('preferred-theme', isDark ? 'dark' : 'light');
+    updateLabel(languageManager.getLanguage());
   });
 
   prefersDark?.addEventListener?.('change', (event) => {
     if (!localStorage.getItem('preferred-theme')) {
       document.body.classList.toggle('dark-mode', event.matches);
-      toggle.textContent = event.matches ? 'Light mode' : 'Dark mode';
       toggle.setAttribute('aria-pressed', event.matches ? 'true' : 'false');
+      updateLabel(languageManager.getLanguage());
     }
   });
+
+  languageManager.onChange(updateLabel);
 }
 
-function setupHeroSlider() {
+function setupHeroSlider(languageManager) {
   const slider = document.querySelector('.hero-slider');
   if (!slider) return;
 
@@ -143,7 +623,7 @@ function setupHeroSlider() {
       if (!video.loop) {
         try {
           video.currentTime = 0;
-        } catch {
+        } catch (error) {
           // Some browsers might not allow resetting the currentTime for certain sources.
         }
       }
@@ -197,6 +677,14 @@ function setupHeroSlider() {
     autoRotateTimer = window.setInterval(nextSlide, AUTO_ROTATE_INTERVAL);
   }
 
+  function updateDotLabels(lang = languageManager.getLanguage()) {
+    if (!dotsContainer) return;
+    const dots = dotsContainer.querySelectorAll('.hero-slider__dot');
+    dots.forEach((dot, index) => {
+      dot.setAttribute('aria-label', languageManager.translate('heroSlider.goToSlide', { index: index + 1 }, lang));
+    });
+  }
+
   function buildDots() {
     if (!dotsContainer || !hasMultipleSlides) return;
 
@@ -206,7 +694,7 @@ function setupHeroSlider() {
       dot.className = 'hero-slider__dot';
       dot.type = 'button';
       dot.setAttribute('role', 'tab');
-      dot.setAttribute('aria-label', `Go to slide ${index + 1}`);
+      dot.setAttribute('aria-label', languageManager.translate('heroSlider.goToSlide', { index: index + 1 }));
       dot.addEventListener('click', () => goToSlide(index));
       dotsContainer.append(dot);
     });
@@ -220,6 +708,7 @@ function setupHeroSlider() {
     dots.forEach((dot, index) => {
       dot.setAttribute('aria-selected', index === currentIndex ? 'true' : 'false');
     });
+    updateDotLabels();
   }
 
   syncSlides();
@@ -236,14 +725,43 @@ function setupHeroSlider() {
 
   buildDots();
   startAutoRotate();
+
+  languageManager.onChange(updateDotLabels);
 }
 
-function setupTourBuilder() {
+function setupTourBuilder(languageManager) {
   const form = document.querySelector('#tour-builder-form');
   const itineraryList = document.querySelector('#itinerary-list');
   const clearButton = document.querySelector('#clear-itinerary');
 
   if (!form || !itineraryList) return;
+
+  const getItemCount = () => itineraryList.querySelectorAll('.itinerary-item').length;
+
+  const updatePlaceholder = (lang = languageManager.getLanguage()) => {
+    const placeholder = itineraryList.querySelector('.itinerary-list__placeholder');
+    const message = languageManager.translate('home.builder.placeholder', {}, lang);
+
+    if (getItemCount() === 0) {
+      if (placeholder) {
+        placeholder.textContent = message;
+      } else {
+        const newPlaceholder = document.createElement('li');
+        newPlaceholder.className = 'itinerary-list__placeholder';
+        newPlaceholder.dataset.i18n = 'home.builder.placeholder';
+        newPlaceholder.textContent = message;
+        itineraryList.append(newPlaceholder);
+      }
+    } else if (placeholder) {
+      placeholder.remove();
+    }
+  };
+
+  const updateRemoveButtons = (lang = languageManager.getLanguage()) => {
+    itineraryList.querySelectorAll('.itinerary-item__remove').forEach((button) => {
+      button.textContent = languageManager.translate('tourBuilder.remove', {}, lang);
+    });
+  };
 
   form.addEventListener('submit', (event) => {
     event.preventDefault();
@@ -264,7 +782,12 @@ function setupTourBuilder() {
     if (date) {
       const meta = document.createElement('div');
       meta.className = 'itinerary-item__meta';
-      meta.innerHTML = `<span>📅 ${new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' }).format(new Date(date))}</span>`;
+      try {
+        const formattedDate = new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' }).format(new Date(date));
+        meta.innerHTML = `<span>📅 ${formattedDate}</span>`;
+      } catch (error) {
+        meta.textContent = `📅 ${date}`;
+      }
       item.append(meta);
     }
 
@@ -277,16 +800,18 @@ function setupTourBuilder() {
     const remove = document.createElement('button');
     remove.type = 'button';
     remove.className = 'itinerary-item__remove';
-    remove.textContent = 'Remove';
+    remove.textContent = languageManager.translate('tourBuilder.remove');
     remove.addEventListener('click', () => {
       item.remove();
       updatePlaceholder();
+      updateRemoveButtons();
     });
 
     item.append(remove);
     itineraryList.append(item);
     form.reset();
     updatePlaceholder();
+    updateRemoveButtons();
   });
 
   clearButton?.addEventListener('click', () => {
@@ -294,17 +819,10 @@ function setupTourBuilder() {
     updatePlaceholder();
   });
 
-  function updatePlaceholder() {
-    if (!itineraryList.children.length) {
-      const placeholder = document.createElement('li');
-      placeholder.className = 'itinerary-list__placeholder';
-      placeholder.textContent = 'Your ideas will appear here. Add the first one to begin crafting the perfect tour.';
-      itineraryList.append(placeholder);
-    } else {
-      const placeholder = itineraryList.querySelector('.itinerary-list__placeholder');
-      placeholder?.remove();
-    }
-  }
+  languageManager.onChange((lang) => {
+    updatePlaceholder(lang);
+    updateRemoveButtons(lang);
+  });
 }
 
 function setCurrentYear() {

--- a/style.css
+++ b/style.css
@@ -238,7 +238,7 @@ body.dark-mode .nav__logo-subtitle {
   transition: transform 0.3s ease;
 }
 
-.theme-toggle {
+.nav__control {
   margin-left: 1.5rem;
   background: rgba(15, 58, 93, 0.12);
   color: var(--accent-strong);
@@ -250,20 +250,34 @@ body.dark-mode .nav__logo-subtitle {
   transition: background var(--transition), transform 0.3s ease;
 }
 
-.theme-toggle:hover,
-.theme-toggle:focus-visible {
+.nav__control:hover,
+.nav__control:focus-visible {
   background: rgba(15, 58, 93, 0.18);
   transform: translateY(-1px);
 }
 
-body.dark-mode .theme-toggle {
+.nav__control + .nav__control {
+  margin-left: 0.75rem;
+}
+
+body.dark-mode .nav__control {
   background: rgba(245, 158, 11, 0.18);
   border-color: rgba(245, 158, 11, 0.35);
 }
 
-body.dark-mode .theme-toggle:hover,
-body.dark-mode .theme-toggle:focus-visible {
+body.dark-mode .nav__control:hover,
+body.dark-mode .nav__control:focus-visible {
   background: rgba(245, 158, 11, 0.28);
+}
+
+.language-toggle[aria-pressed='true'] {
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
+}
+
+body.dark-mode .language-toggle[aria-pressed='true'] {
+  color: #0b1f3a;
 }
 
 .hero-slider {


### PR DESCRIPTION
## Summary
- add a language toggle next to the theme switcher and remember the preferred locale
- translate navigation, hero content, forms, and aria labels across every page with a shared dictionary
- reuse the nav control styling for both toggles and highlight the active language

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d367400e98833096a01432d6663cf3