### PR TITLE
Restyle favorites section with carousel discounts

### DIFF
--- a/index.html
+++ b/index.html
@@ -194,170 +194,135 @@
       <div class="section__intro">
         <h2 id="favorites-heading" data-i18n="home.favorites.heading">Adventures Loved by Travelers</h2>
         <p data-i18n="home.favorites.copy">
-          Not sure where to start? Explore the tours our guests book and love the most.
+          Swipe through limited-time offers on the tours our guests love the most.
         </p>
       </div>
-      <div class="favorites-grid" role="list">
-        <article class="card favorite-card" role="listitem">
-          <div class="favorite-card__media">
-            <img
-              src="https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=1200&q=80"
-              alt="A snorkeler swims alongside a whale shark in crystal clear water"
-              loading="lazy"
-            />
-            <span class="favorite-card__tag" data-i18n="home.favorites.card1.tag">Top pick</span>
+      <div class="favorites-carousel" data-favorites-carousel>
+        <button
+          class="favorites-carousel__arrow favorites-carousel__arrow--prev"
+          type="button"
+          data-carousel-arrow="prev"
+          aria-label="Previous tours"
+          data-i18n="home.favorites.previous"
+          data-i18n-attr="aria-label"
+        >
+          <span aria-hidden="true">❮</span>
+        </button>
+        <div class="favorites-carousel__viewport">
+          <div class="favorites-carousel__track" role="list">
+            <article class="card favorite-card" role="listitem">
+              <div class="favorite-card__media">
+                <img
+                  src="https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=1200&q=80"
+                  alt="A snorkeler swims alongside a whale shark in crystal clear water"
+                  loading="lazy"
+                />
+                <span class="favorite-card__tag" data-i18n="home.favorites.card1.tag">Top pick</span>
+                <span class="favorite-card__badge" data-i18n="home.favorites.card1.badge">-30%</span>
+              </div>
+              <div class="favorite-card__body">
+                <h3 data-i18n="home.favorites.card1.title">Swimming with Whale Sharks</h3>
+                <p class="favorite-card__deal" data-i18n="home.favorites.card1.deal">Up to 30% discount</p>
+                <p class="favorite-card__copy" data-i18n="home.favorites.card1.copy">
+                  Charter a private boat with marine biologist guides and slip into the water beside gentle giants at sunrise.
+                </p>
+                <a
+                  class="button button--primary favorite-card__cta"
+                  href="build-your-tours.html"
+                  data-i18n="home.favorites.card1.cta"
+                >
+                  More information
+                </a>
+              </div>
+            </article>
+            <article class="card favorite-card" role="listitem">
+              <div class="favorite-card__media">
+                <img
+                  src="https://images.unsplash.com/photo-1580137335232-0ef3c08a3be4?auto=format&fit=crop&w=1200&q=80"
+                  alt="Friends enjoying tacos and drinks at a beachfront table"
+                  loading="lazy"
+                />
+                <span class="favorite-card__tag" data-i18n="home.favorites.card2.tag">Guest favorite</span>
+                <span class="favorite-card__badge" data-i18n="home.favorites.card2.badge">-25%</span>
+              </div>
+              <div class="favorite-card__body">
+                <h3 data-i18n="home.favorites.card2.title">The Taco Tour</h3>
+                <p class="favorite-card__deal" data-i18n="home.favorites.card2.deal">Up to 25% discount</p>
+                <p class="favorite-card__copy" data-i18n="home.favorites.card2.copy">
+                  Taste your way through hidden taquerías with a local host curating mezcal pairings and street-food legends.
+                </p>
+                <a
+                  class="button button--primary favorite-card__cta"
+                  href="build-your-tours.html"
+                  data-i18n="home.favorites.card2.cta"
+                >
+                  More information
+                </a>
+              </div>
+            </article>
+            <article class="card favorite-card" role="listitem">
+              <div class="favorite-card__media">
+                <img
+                  src="https://images.unsplash.com/photo-1526481280695-3c46973c8a56?auto=format&fit=crop&w=1200&q=80"
+                  alt="Snorkeler gliding over turquoise water in Cozumel"
+                  loading="lazy"
+                />
+                <span class="favorite-card__tag" data-i18n="home.favorites.card3.tag">Limited spots</span>
+                <span class="favorite-card__badge" data-i18n="home.favorites.card3.badge">-22%</span>
+              </div>
+              <div class="favorite-card__body">
+                <h3 data-i18n="home.favorites.card3.title">El Cielo Cozumel Snorkeling</h3>
+                <p class="favorite-card__deal" data-i18n="home.favorites.card3.deal">Up to 22% discount</p>
+                <p class="favorite-card__copy" data-i18n="home.favorites.card3.copy">
+                  Float above starfish gardens and neon reefs in Cozumel with a captain who times the sandbar at its clearest.
+                </p>
+                <a
+                  class="button button--primary favorite-card__cta"
+                  href="build-your-tours.html"
+                  data-i18n="home.favorites.card3.cta"
+                >
+                  More information
+                </a>
+              </div>
+            </article>
+            <article class="card favorite-card" role="listitem">
+              <div class="favorite-card__media">
+                <img
+                  src="https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=1200&q=80"
+                  alt="Traveler posing at a scenic overlook near Tulum ruins"
+                  loading="lazy"
+                />
+                <span class="favorite-card__tag" data-i18n="home.favorites.card4.tag">Photo ready</span>
+                <span class="favorite-card__badge" data-i18n="home.favorites.card4.badge">-18%</span>
+              </div>
+              <div class="favorite-card__body">
+                <h3 data-i18n="home.favorites.card4.title">Tulum Insta Experience</h3>
+                <p class="favorite-card__deal" data-i18n="home.favorites.card4.deal">Up to 18% discount</p>
+                <p class="favorite-card__copy" data-i18n="home.favorites.card4.copy">
+                  Capture cinematic shots across Tulum’s ruins and cenotes with a creative director setting the scene for every
+                  moment.
+                </p>
+                <a
+                  class="button button--primary favorite-card__cta"
+                  href="build-your-tours.html"
+                  data-i18n="home.favorites.card4.cta"
+                >
+                  More information
+                </a>
+              </div>
+            </article>
           </div>
-          <div class="favorite-card__body">
-            <div class="favorite-card__header">
-              <h3 data-i18n="home.favorites.card1.title">Swimming with Whale Sharks</h3>
-              <p class="favorite-card__price">
-                <span class="favorite-card__price-amount" data-i18n="home.favorites.card1.price">$160 USD</span>
-                <span class="favorite-card__price-note" data-i18n="home.favorites.card1.priceNote">per guest</span>
-              </p>
-            </div>
-            <ul class="favorite-card__meta">
-              <li>
-                <span aria-hidden="true">🕒</span>
-                <span data-i18n="home.favorites.card1.duration">6.5 hours</span>
-              </li>
-              <li>
-                <span aria-hidden="true">👥</span>
-                <span data-i18n="home.favorites.card1.group">Max 8 guests</span>
-              </li>
-              <li>
-                <span aria-hidden="true">🎒</span>
-                <span data-i18n="home.favorites.card1.age">Ages 10+</span>
-              </li>
-            </ul>
-            <a
-              class="button button--primary favorite-card__cta"
-              href="build-your-tours.html"
-              data-i18n="home.favorites.card1.cta"
-            >
-              Plan this tour
-            </a>
-          </div>
-        </article>
-        <article class="card favorite-card" role="listitem">
-          <div class="favorite-card__media">
-            <img
-              src="https://images.unsplash.com/photo-1580137335232-0ef3c08a3be4?auto=format&fit=crop&w=1200&q=80"
-              alt="Friends enjoying tacos and drinks at a beachfront table"
-              loading="lazy"
-            />
-            <span class="favorite-card__tag" data-i18n="home.favorites.card2.tag">Guest favorite</span>
-          </div>
-          <div class="favorite-card__body">
-            <div class="favorite-card__header">
-              <h3 data-i18n="home.favorites.card2.title">The Taco Tour</h3>
-              <p class="favorite-card__price">
-                <span class="favorite-card__price-amount" data-i18n="home.favorites.card2.price">$97 USD</span>
-                <span class="favorite-card__price-note" data-i18n="home.favorites.card2.priceNote">per guest</span>
-              </p>
-            </div>
-            <ul class="favorite-card__meta">
-              <li>
-                <span aria-hidden="true">🕒</span>
-                <span data-i18n="home.favorites.card2.duration">4 hours</span>
-              </li>
-              <li>
-                <span aria-hidden="true">👥</span>
-                <span data-i18n="home.favorites.card2.group">Up to 10 guests</span>
-              </li>
-              <li>
-                <span aria-hidden="true">🍽️</span>
-                <span data-i18n="home.favorites.card2.age">Family friendly</span>
-              </li>
-            </ul>
-            <a
-              class="button button--primary favorite-card__cta"
-              href="build-your-tours.html"
-              data-i18n="home.favorites.card2.cta"
-            >
-              Taste the flavors
-            </a>
-          </div>
-        </article>
-        <article class="card favorite-card" role="listitem">
-          <div class="favorite-card__media">
-            <img
-              src="https://images.unsplash.com/photo-1526481280695-3c46973c8a56?auto=format&fit=crop&w=1200&q=80"
-              alt="Snorkeler gliding over turquoise water in Cozumel"
-              loading="lazy"
-            />
-            <span class="favorite-card__tag" data-i18n="home.favorites.card3.tag">Limited spots</span>
-          </div>
-          <div class="favorite-card__body">
-            <div class="favorite-card__header">
-              <h3 data-i18n="home.favorites.card3.title">El Cielo Cozumel Snorkeling</h3>
-              <p class="favorite-card__price">
-                <span class="favorite-card__price-amount" data-i18n="home.favorites.card3.price">$109 USD</span>
-                <span class="favorite-card__price-note" data-i18n="home.favorites.card3.priceNote">per guest</span>
-              </p>
-            </div>
-            <ul class="favorite-card__meta">
-              <li>
-                <span aria-hidden="true">🕒</span>
-                <span data-i18n="home.favorites.card3.duration">5 hours</span>
-              </li>
-              <li>
-                <span aria-hidden="true">👥</span>
-                <span data-i18n="home.favorites.card3.group">Small-group charter</span>
-              </li>
-              <li>
-                <span aria-hidden="true">🌊</span>
-                <span data-i18n="home.favorites.card3.age">All swim levels</span>
-              </li>
-            </ul>
-            <a
-              class="button button--primary favorite-card__cta"
-              href="build-your-tours.html"
-              data-i18n="home.favorites.card3.cta"
-            >
-              Snorkel the sandbar
-            </a>
-          </div>
-        </article>
-        <article class="card favorite-card" role="listitem">
-          <div class="favorite-card__media">
-            <img
-              src="https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=1200&q=80"
-              alt="Traveler posing at a scenic overlook near Tulum ruins"
-              loading="lazy"
-            />
-            <span class="favorite-card__tag" data-i18n="home.favorites.card4.tag">Photo ready</span>
-          </div>
-          <div class="favorite-card__body">
-            <div class="favorite-card__header">
-              <h3 data-i18n="home.favorites.card4.title">Tulum Insta Experience</h3>
-              <p class="favorite-card__price">
-                <span class="favorite-card__price-amount" data-i18n="home.favorites.card4.price">$111 USD</span>
-                <span class="favorite-card__price-note" data-i18n="home.favorites.card4.priceNote">per guest</span>
-              </p>
-            </div>
-            <ul class="favorite-card__meta">
-              <li>
-                <span aria-hidden="true">🕒</span>
-                <span data-i18n="home.favorites.card4.duration">6 hours</span>
-              </li>
-              <li>
-                <span aria-hidden="true">👥</span>
-                <span data-i18n="home.favorites.card4.group">Private host</span>
-              </li>
-              <li>
-                <span aria-hidden="true">📸</span>
-                <span data-i18n="home.favorites.card4.age">Includes content crew</span>
-              </li>
-            </ul>
-            <a
-              class="button button--primary favorite-card__cta"
-              href="build-your-tours.html"
-              data-i18n="home.favorites.card4.cta"
-            >
-              Capture the magic
-            </a>
-          </div>
-        </article>
+        </div>
+        <button
+          class="favorites-carousel__arrow favorites-carousel__arrow--next"
+          type="button"
+          data-carousel-arrow="next"
+          aria-label="Next tours"
+          data-i18n="home.favorites.next"
+          data-i18n-attr="aria-label"
+        >
+          <span aria-hidden="true">❯</span>
+        </button>
       </div>
     </section>
 

--- a/script.js
+++ b/script.js
@@ -41,39 +41,37 @@ const translations = {
       'home.difference.excellence.title': 'Excellence',
       'home.difference.excellence.copy': 'We don’t claim it — our guests do. Five stars, every time.',
       'home.favorites.heading': 'Adventures Loved by Travelers',
-      'home.favorites.copy': 'Not sure where to start? Explore the tours our guests book and love the most.',
+      'home.favorites.copy': 'Swipe through limited-time offers on the tours our guests love the most.',
+      'home.favorites.previous': 'Previous tours',
+      'home.favorites.next': 'Next tours',
       'home.favorites.card1.tag': 'Top pick',
       'home.favorites.card1.title': 'Swimming with Whale Sharks',
-      'home.favorites.card1.price': '$160 USD',
-      'home.favorites.card1.priceNote': 'per guest',
-      'home.favorites.card1.duration': '6.5 hours',
-      'home.favorites.card1.group': 'Max 8 guests',
-      'home.favorites.card1.age': 'Ages 10+',
-      'home.favorites.card1.cta': 'Plan this tour',
+      'home.favorites.card1.badge': '-30%',
+      'home.favorites.card1.deal': 'Up to 30% discount',
+      'home.favorites.card1.copy':
+        'Charter a private boat with marine biologist guides and slip into the water beside gentle giants at sunrise.',
+      'home.favorites.card1.cta': 'More information',
       'home.favorites.card2.tag': 'Guest favorite',
       'home.favorites.card2.title': 'The Taco Tour',
-      'home.favorites.card2.price': '$97 USD',
-      'home.favorites.card2.priceNote': 'per guest',
-      'home.favorites.card2.duration': '4 hours',
-      'home.favorites.card2.group': 'Up to 10 guests',
-      'home.favorites.card2.age': 'Family friendly',
-      'home.favorites.card2.cta': 'Taste the flavors',
+      'home.favorites.card2.badge': '-25%',
+      'home.favorites.card2.deal': 'Up to 25% discount',
+      'home.favorites.card2.copy':
+        'Taste your way through hidden taquerías with a local host curating mezcal pairings and street-food legends.',
+      'home.favorites.card2.cta': 'More information',
       'home.favorites.card3.tag': 'Limited spots',
       'home.favorites.card3.title': 'El Cielo Cozumel Snorkeling',
-      'home.favorites.card3.price': '$109 USD',
-      'home.favorites.card3.priceNote': 'per guest',
-      'home.favorites.card3.duration': '5 hours',
-      'home.favorites.card3.group': 'Small-group charter',
-      'home.favorites.card3.age': 'All swim levels',
-      'home.favorites.card3.cta': 'Snorkel the sandbar',
+      'home.favorites.card3.badge': '-22%',
+      'home.favorites.card3.deal': 'Up to 22% discount',
+      'home.favorites.card3.copy':
+        'Float above starfish gardens and neon reefs in Cozumel with a captain who times the sandbar at its clearest.',
+      'home.favorites.card3.cta': 'More information',
       'home.favorites.card4.tag': 'Photo ready',
       'home.favorites.card4.title': 'Tulum Insta Experience',
-      'home.favorites.card4.price': '$111 USD',
-      'home.favorites.card4.priceNote': 'per guest',
-      'home.favorites.card4.duration': '6 hours',
-      'home.favorites.card4.group': 'Private host',
-      'home.favorites.card4.age': 'Includes content crew',
-      'home.favorites.card4.cta': 'Capture the magic',
+      'home.favorites.card4.badge': '-18%',
+      'home.favorites.card4.deal': 'Up to 18% discount',
+      'home.favorites.card4.copy':
+        'Capture cinematic shots across Tulum’s ruins and cenotes with a creative director setting the scene for every moment.',
+      'home.favorites.card4.cta': 'More information',
       'home.builder.eyebrow': 'Build your tour',
       'home.builder.heading': 'Design a custom itinerary in minutes',
       'home.builder.copy':
@@ -219,39 +217,37 @@ const translations = {
       'home.difference.excellence.title': 'Excelencia',
       'home.difference.excellence.copy': 'No lo decimos nosotros: lo dicen nuestros huéspedes. Cinco estrellas siempre.',
       'home.favorites.heading': 'Aventuras que enamoran a los viajeros',
-      'home.favorites.copy': '¿No sabes por dónde empezar? Explora los tours que nuestros huéspedes reservan y aman.',
+      'home.favorites.copy': 'Desliza para conocer las ofertas limitadas de los tours que más enamoran a nuestros viajeros.',
+      'home.favorites.previous': 'Tours anteriores',
+      'home.favorites.next': 'Más tours',
       'home.favorites.card1.tag': 'Imprescindible',
       'home.favorites.card1.title': 'Nado con tiburón ballena',
-      'home.favorites.card1.price': '$160 USD',
-      'home.favorites.card1.priceNote': 'por persona',
-      'home.favorites.card1.duration': '6.5 horas',
-      'home.favorites.card1.group': 'Máx. 8 viajeros',
-      'home.favorites.card1.age': 'Edades 10+',
-      'home.favorites.card1.cta': 'Planear este tour',
+      'home.favorites.card1.badge': '-30%',
+      'home.favorites.card1.deal': 'Hasta 30% de descuento',
+      'home.favorites.card1.copy':
+        'Alquila un barco privado con guías biólogos marinos y nada junto a estos gigantes pacíficos al amanecer.',
+      'home.favorites.card1.cta': 'Más información',
       'home.favorites.card2.tag': 'Favorito de los huéspedes',
       'home.favorites.card2.title': 'El Taco Tour',
-      'home.favorites.card2.price': '$97 USD',
-      'home.favorites.card2.priceNote': 'por persona',
-      'home.favorites.card2.duration': '4 horas',
-      'home.favorites.card2.group': 'Hasta 10 viajeros',
-      'home.favorites.card2.age': 'Ideal para familias',
-      'home.favorites.card2.cta': 'Prueba los sabores',
+      'home.favorites.card2.badge': '-25%',
+      'home.favorites.card2.deal': 'Hasta 25% de descuento',
+      'home.favorites.card2.copy':
+        'Saborea taquerías ocultas con un anfitrión local que marida mezcales y comparte leyendas callejeras.',
+      'home.favorites.card2.cta': 'Más información',
       'home.favorites.card3.tag': 'Cupos limitados',
       'home.favorites.card3.title': 'Snorkel en El Cielo Cozumel',
-      'home.favorites.card3.price': '$109 USD',
-      'home.favorites.card3.priceNote': 'por persona',
-      'home.favorites.card3.duration': '5 horas',
-      'home.favorites.card3.group': 'Charter para grupos pequeños',
-      'home.favorites.card3.age': 'Para todos los niveles de nado',
-      'home.favorites.card3.cta': 'Haz snorkel en el banco de arena',
+      'home.favorites.card3.badge': '-22%',
+      'home.favorites.card3.deal': 'Hasta 22% de descuento',
+      'home.favorites.card3.copy':
+        'Flota sobre jardines de estrellas de mar y arrecifes neón en Cozumel con un capitán que elige el banco de arena en su punto más claro.',
+      'home.favorites.card3.cta': 'Más información',
       'home.favorites.card4.tag': 'Listo para fotos',
       'home.favorites.card4.title': 'Experiencia Insta en Tulum',
-      'home.favorites.card4.price': '$111 USD',
-      'home.favorites.card4.priceNote': 'por persona',
-      'home.favorites.card4.duration': '6 horas',
-      'home.favorites.card4.group': 'Anfitrión privado',
-      'home.favorites.card4.age': 'Incluye equipo de contenido',
-      'home.favorites.card4.cta': 'Captura la magia',
+      'home.favorites.card4.badge': '-18%',
+      'home.favorites.card4.deal': 'Hasta 18% de descuento',
+      'home.favorites.card4.copy':
+        'Captura tomas cinematográficas en las ruinas y cenotes de Tulum con un director creativo preparando cada escena.',
+      'home.favorites.card4.cta': 'Más información',
       'home.builder.eyebrow': 'Diseña tu tour',
       'home.builder.heading': 'Crea un itinerario a medida en minutos',
       'home.builder.copy':
@@ -487,6 +483,7 @@ function createLanguageManager(pageKey) {
     setupThemeToggle(prefersDark, languageManager);
     window.addEventListener('resize', scheduleNavControlWidthSync, { passive: true });
     setupHeroSlider(languageManager);
+    setupFavoritesCarousel();
     setupTourBuilder(languageManager);
     setCurrentYear();
 
@@ -824,6 +821,77 @@ function setupHeroSlider(languageManager) {
   startAutoRotate();
 
   languageManager.onChange(updateDotLabels);
+}
+
+function setupFavoritesCarousel() {
+  const carousel = document.querySelector('[data-favorites-carousel]');
+  if (!carousel) return;
+
+  const viewport = carousel.querySelector('.favorites-carousel__viewport');
+  const track = carousel.querySelector('.favorites-carousel__track');
+  const prevButton = carousel.querySelector('[data-carousel-arrow="prev"]');
+  const nextButton = carousel.querySelector('[data-carousel-arrow="next"]');
+
+  if (!viewport || !track) return;
+
+  const cards = Array.from(track.querySelectorAll('.favorite-card'));
+
+  const getGap = () => {
+    const styles = window.getComputedStyle(track);
+    const gapValue = parseFloat(styles.columnGap || styles.gap || '0');
+    return Number.isFinite(gapValue) ? gapValue : 0;
+  };
+
+  const updateArrowState = () => {
+    const maxScroll = Math.max(0, viewport.scrollWidth - viewport.clientWidth);
+    const atStart = viewport.scrollLeft <= 1;
+    const atEnd = viewport.scrollLeft >= maxScroll - 1;
+
+    if (prevButton) {
+      prevButton.disabled = atStart;
+    }
+    if (nextButton) {
+      nextButton.disabled = atEnd;
+    }
+
+    carousel.classList.toggle('favorites-carousel--is-scrollable', maxScroll > 1);
+  };
+
+  const scrollByDirection = (direction) => {
+    const multiplier = direction < 0 ? -1 : 1;
+    const cardWidth = cards.length ? cards[0].getBoundingClientRect().width : viewport.clientWidth;
+    const target = viewport.scrollLeft + multiplier * (cardWidth + getGap());
+    const maxScroll = viewport.scrollWidth - viewport.clientWidth;
+    const clamped = Math.max(0, Math.min(target, maxScroll));
+    viewport.scrollTo({ left: clamped, behavior: 'smooth' });
+  };
+
+  prevButton?.addEventListener('click', () => scrollByDirection(-1));
+  nextButton?.addEventListener('click', () => scrollByDirection(1));
+
+  let scrollRaf = null;
+  const handleScroll = () => {
+    if (scrollRaf) return;
+    scrollRaf = window.requestAnimationFrame(() => {
+      scrollRaf = null;
+      updateArrowState();
+    });
+  };
+
+  viewport.addEventListener('scroll', handleScroll, { passive: true });
+
+  let resizeRaf = null;
+  const handleResize = () => {
+    if (resizeRaf) return;
+    resizeRaf = window.requestAnimationFrame(() => {
+      resizeRaf = null;
+      updateArrowState();
+    });
+  };
+
+  window.addEventListener('resize', handleResize);
+
+  updateArrowState();
 }
 
 function setupTourBuilder(languageManager) {

--- a/style.css
+++ b/style.css
@@ -14,6 +14,14 @@
   --radius-md: 18px;
   --radius-sm: 12px;
   --transition: all 0.4s ease;
+  --favorite-card-bg: linear-gradient(180deg, rgba(11, 40, 73, 0.95) 0%, rgba(6, 26, 50, 0.97) 100%);
+  --favorite-card-border: rgba(15, 76, 129, 0.45);
+  --favorite-card-text: #f1f7ff;
+  --favorite-card-muted: rgba(221, 233, 250, 0.78);
+  --favorite-card-shadow: 0 25px 50px rgba(6, 26, 50, 0.35);
+  --favorite-card-badge-bg: linear-gradient(135deg, #38bdf8 0%, #2563eb 100%);
+  --favorite-card-badge-text: #f8fbff;
+  --favorite-card-deal-color: #38bdf8;
 }
 
 html.dark-mode,
@@ -29,6 +37,14 @@ body.dark-mode {
   --nav-bg: rgba(17, 45, 78, 0.95);
   --nav-border: rgba(245, 208, 113, 0.25);
   --shadow: 0 24px 36px rgba(4, 20, 41, 0.55);
+  --favorite-card-bg: linear-gradient(180deg, rgba(15, 40, 68, 0.92) 0%, rgba(5, 20, 38, 0.92) 100%);
+  --favorite-card-border: rgba(245, 158, 11, 0.28);
+  --favorite-card-text: #fff8eb;
+  --favorite-card-muted: rgba(255, 227, 189, 0.78);
+  --favorite-card-shadow: 0 30px 60px rgba(1, 10, 20, 0.55);
+  --favorite-card-badge-bg: linear-gradient(135deg, #f59e0b 0%, #f97316 100%);
+  --favorite-card-badge-text: #0b1a2e;
+  --favorite-card-deal-color: #fbbf24;
 }
 
 * {
@@ -550,18 +566,44 @@ body.dark-mode .difference-item__icon {
 }
 
 .section--favorites {
-  background: linear-gradient(135deg, rgba(15, 76, 129, 0.12), rgba(255, 200, 64, 0.16));
+  background: linear-gradient(135deg, rgba(5, 26, 48, 0.95) 0%, rgba(17, 72, 118, 0.78) 100%);
+  position: relative;
+  overflow: hidden;
 }
 
 html.dark-mode .section--favorites,
 body.dark-mode .section--favorites {
-  background: linear-gradient(135deg, rgba(11, 26, 46, 0.6), rgba(245, 158, 11, 0.22));
+  background: linear-gradient(135deg, rgba(2, 12, 24, 0.92) 0%, rgba(12, 30, 52, 0.92) 100%);
 }
 
-.favorites-grid {
-  display: grid;
-  gap: clamp(1.5rem, 4vw, 2.5rem);
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+.favorites-carousel {
+  position: relative;
+  --favorites-viewport-padding: clamp(1.25rem, 6vw, 3rem);
+  --favorites-gap: clamp(1rem, 2.8vw, 1.75rem);
+}
+
+.favorites-carousel:not(.favorites-carousel--is-scrollable) .favorites-carousel__arrow {
+  display: none;
+}
+
+.favorites-carousel__viewport {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+  padding: 1rem 0;
+  padding-inline: var(--favorites-viewport-padding);
+  scroll-snap-type: x mandatory;
+  scroll-padding-inline: var(--favorites-viewport-padding);
+}
+
+.favorites-carousel__viewport::-webkit-scrollbar {
+  display: none;
+}
+
+.favorites-carousel__track {
+  display: flex;
+  gap: var(--favorites-gap);
+  align-items: stretch;
 }
 
 .favorite-card {
@@ -569,6 +611,29 @@ body.dark-mode .section--favorites {
   overflow: hidden;
   display: flex;
   flex-direction: column;
+  flex: 0 0 clamp(240px, 55vw, 340px);
+  min-height: 100%;
+  border-radius: var(--radius-lg);
+  background: var(--favorite-card-bg);
+  border: 1px solid var(--favorite-card-border);
+  box-shadow: var(--favorite-card-shadow);
+  color: var(--favorite-card-text);
+  scroll-snap-align: center;
+  scroll-snap-stop: always;
+  transition: transform 0.4s ease, box-shadow 0.4s ease;
+}
+
+.favorite-card:hover,
+.favorite-card:focus-within {
+  transform: translateY(-8px);
+  box-shadow: 0 32px 60px rgba(5, 20, 38, 0.45);
+}
+
+html.dark-mode .favorite-card:hover,
+body.dark-mode .favorite-card:hover,
+html.dark-mode .favorite-card:focus-within,
+body.dark-mode .favorite-card:focus-within {
+  box-shadow: 0 36px 60px rgba(0, 0, 0, 0.55);
 }
 
 .favorite-card__media {
@@ -577,10 +642,19 @@ body.dark-mode .section--favorites {
   overflow: hidden;
 }
 
+.favorite-card__media::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(3, 12, 24, 0) 55%, rgba(3, 12, 24, 0.6) 100%);
+  pointer-events: none;
+}
+
 .favorite-card__media img {
   width: 100%;
   height: 100%;
   object-fit: cover;
+  transform: scale(1);
   transition: transform 0.6s ease;
 }
 
@@ -589,83 +663,139 @@ body.dark-mode .section--favorites {
   transform: scale(1.06);
 }
 
-.favorite-card__tag {
+.favorite-card__tag,
+.favorite-card__badge {
   position: absolute;
   top: 1rem;
-  left: 1rem;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   padding: 0.35rem 0.9rem;
   border-radius: 999px;
-  background: var(--accent-strong);
-  color: #fff8eb;
   font-size: 0.7rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   font-weight: 700;
-  box-shadow: 0 12px 24px rgba(15, 58, 93, 0.26);
+}
+
+.favorite-card__tag {
+  left: 1rem;
+  background: rgba(8, 31, 55, 0.8);
+  color: var(--favorite-card-text);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.favorite-card__badge {
+  right: 1rem;
+  background: var(--favorite-card-badge-bg);
+  color: var(--favorite-card-badge-text);
+  box-shadow: 0 12px 24px rgba(15, 58, 93, 0.4);
 }
 
 .favorite-card__body {
   display: flex;
   flex-direction: column;
-  gap: clamp(1rem, 2vw, 1.35rem);
+  flex: 1;
+  gap: clamp(0.75rem, 2vw, 1.35rem);
   padding: clamp(1.5rem, 3vw, 2.35rem);
 }
 
-.favorite-card__header {
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
+.favorite-card__body h3 {
+  margin: 0;
+  font-size: clamp(1.25rem, 2.6vw, 1.6rem);
 }
 
-.favorite-card__header h3 {
+.favorite-card__deal {
   margin: 0;
-  font-size: clamp(1.2rem, 2.6vw, 1.5rem);
-}
-
-.favorite-card__price {
-  display: flex;
-  align-items: baseline;
-  gap: 0.5rem;
-  margin: 0;
-  color: var(--accent-strong);
   font-weight: 700;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
+  font-size: 0.85rem;
+  color: var(--favorite-card-deal-color);
 }
 
-.favorite-card__price-amount {
-  font-size: 1rem;
-}
-
-.favorite-card__price-note {
-  font-size: 0.75rem;
-  color: var(--text-muted);
-  font-weight: 600;
-}
-
-.favorite-card__meta {
+.favorite-card__copy {
   margin: 0;
-  padding: 0;
-  list-style: none;
-  display: grid;
-  gap: 0.5rem;
-  color: var(--text-muted);
-  font-size: 0.9rem;
-}
-
-.favorite-card__meta li {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
+  color: var(--favorite-card-muted);
+  font-size: 0.95rem;
+  line-height: 1.6;
 }
 
 .favorite-card__cta {
-  align-self: flex-start;
   margin-top: auto;
-  padding-inline: 1.6rem;
+  align-self: stretch;
+  width: 100%;
+  justify-content: center;
+  padding: 0.85rem 1.6rem;
+  font-size: 0.95rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  box-shadow: 0 20px 40px rgba(15, 76, 129, 0.35);
+}
+
+.favorite-card__cta:hover,
+.favorite-card__cta:focus-visible {
+  box-shadow: 0 26px 55px rgba(15, 76, 129, 0.45);
+}
+
+.favorites-carousel__arrow {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 3rem;
+  height: 3rem;
+  border-radius: 999px;
+  border: 1px solid var(--favorite-card-border);
+  background: rgba(5, 24, 45, 0.9);
+  color: var(--favorite-card-text);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  box-shadow: 0 20px 40px rgba(5, 20, 38, 0.4);
+  transition: transform 0.3s ease, box-shadow 0.3s ease, opacity 0.3s ease;
+  z-index: 2;
+}
+
+.favorites-carousel__arrow--prev {
+  left: clamp(0.5rem, 4vw, 2.5rem);
+}
+
+.favorites-carousel__arrow--next {
+  right: clamp(0.5rem, 4vw, 2.5rem);
+}
+
+.favorites-carousel__arrow span {
+  font-size: 1.25rem;
+  line-height: 1;
+}
+
+.favorites-carousel__arrow:hover,
+.favorites-carousel__arrow:focus-visible {
+  transform: translateY(-50%) scale(1.05);
+  box-shadow: 0 28px 45px rgba(5, 20, 38, 0.5);
+}
+
+.favorites-carousel__arrow:focus-visible {
+  outline: 2px solid var(--favorite-card-deal-color);
+  outline-offset: 3px;
+}
+
+.favorites-carousel__arrow[disabled] {
+  opacity: 0.35;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+@media (max-width: 640px) {
+  .favorites-carousel__arrow {
+    display: none;
+  }
+
+  .favorites-carousel__viewport {
+    padding-inline: 1rem;
+    scroll-padding-inline: 1rem;
+  }
 }
 
 .tour-builder {


### PR DESCRIPTION
## Summary
- restyle the favorites section into a dark blue carousel with discount messaging and a full-width CTA button
- add themed styles and variables for the new card layout, arrows, and badge treatments
- update translations and scripts to support new copy plus left/right navigation controls

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d3781b637883308fb14cc293a52802