### PR TITLE
Adjust favorites section styling

### DIFF
--- a/style.css
+++ b/style.css
@@ -569,6 +569,21 @@ body.dark-mode .difference-item__icon {
   background: linear-gradient(135deg, rgba(5, 26, 48, 0.95) 0%, rgba(17, 72, 118, 0.78) 100%);
   position: relative;
   overflow: hidden;
+  --favorites-heading-color: #facc15;
+  --favorites-subtext-color: #fde68a;
+  --favorite-card-text: #fef3c7;
+  --favorite-card-muted: rgba(254, 243, 199, 0.9);
+  --favorite-card-deal-color: #fbbf24;
+  --favorite-card-badge-bg: linear-gradient(135deg, #f97316 0%, #facc15 100%);
+  --favorite-card-badge-text: #0b1a2e;
+}
+
+.section--favorites .section__intro h2 {
+  color: var(--favorites-heading-color);
+}
+
+.section--favorites .section__intro p {
+  color: var(--favorites-subtext-color);
 }
 
 html.dark-mode .section--favorites,
@@ -611,7 +626,7 @@ body.dark-mode .section--favorites {
   overflow: hidden;
   display: flex;
   flex-direction: column;
-  flex: 0 0 clamp(240px, 55vw, 340px);
+  flex: 0 0 clamp(280px, 70vw, 420px);
   min-height: 100%;
   border-radius: var(--radius-lg);
   background: var(--favorite-card-bg);
@@ -638,8 +653,8 @@ body.dark-mode .favorite-card:focus-within {
 
 .favorite-card__media {
   position: relative;
-  aspect-ratio: 4 / 3;
   overflow: hidden;
+  height: clamp(220px, 55vw, 360px);
 }
 
 .favorite-card__media::after {


### PR DESCRIPTION
## Summary
- restyle the favorites section intro to use warm yellow and orange tones against the blue background
- expand the favorite tour cards and increase media height so tour images fill the cards with minimal padding

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d37c1e526c8330bdc42e69f9564696