### PR TITLE
Switch tour booking forms from JSON to FormData for Formspree

### DIFF
--- a/tour-cenotes-express.html
+++ b/tour-cenotes-express.html
@@ -613,25 +613,28 @@ function subBk(){
   var date  = document.getElementById('bkDate')  && document.getElementById('bkDate').value  || 'TBD';
   var hotel = document.getElementById('bkHotel') && document.getElementById('bkHotel').value.trim() || 'N/A';
   var notes = document.getElementById('bkNotes') && document.getElementById('bkNotes').value.trim() || 'None';
-  var pInfo = (pricing[selPax] && selPax)
-    ? selPax + ' guests — $' + (pricing[selPax] * selPax) + ' USD total'
+  var guests = selPax || 1;
+  var pricePerPerson = (pricing && pricing[guests]) ? pricing[guests] : 0;
+  var pInfo = pricePerPerson
+    ? guests + ' guests — $' + (pricePerPerson * guests) + ' USD total ($' + pricePerPerson + '/person)'
     : 'Price on request';
   var btn = document.querySelector('.bk-sub');
   if(btn){ btn.disabled = true; btn.textContent = 'Sending…'; }
+  var fd = new FormData();
+  fd.append("_subject", "Booking Request: Hidden Cenotes Express");
+  fd.append("_replyto", email);
+  fd.append("tour", "Hidden Cenotes Express");
+  fd.append("email", email);
+  fd.append("name", name);
+  fd.append("phone", phone);
+  fd.append("date", date);
+  fd.append("hotel_pickup", hotel);
+  fd.append("guests_and_price", pInfo);
+  fd.append("special_notes", notes);
   fetch('https://formspree.io/f/xbdpbgkw', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
-    body: JSON.stringify({
-      _subject: "Booking: Hidden Cenotes Express",
-      email: email,
-      name: name,
-      phone: phone,
-      date: date,
-      hotel: hotel,
-      pricing: pInfo,
-      notes: notes,
-      tour: "Hidden Cenotes Express"
-    })
+    body: fd,
+    headers: { 'Accept': 'application/json' }
   })
   .then(function(res){ return res.json(); })
   .then(function(data){
@@ -642,12 +645,13 @@ function subBk(){
       if(form) form.style.display = 'none';
       if(suc)  suc.style.display  = 'block';
     } else {
-      alert('Something went wrong. Please try again or email us at info@beyondthereefmexico.com');
+      var errMsg = (data.errors && data.errors[0] && data.errors[0].message) || 'Unknown error';
+      alert('Submission error: ' + errMsg + '. Please email us at info@beyondthereefmexico.com');
     }
   })
-  .catch(function(){
+  .catch(function(err){
     if(btn){ btn.disabled = false; btn.textContent = 'Request to Book →'; }
-    alert('Could not send your request. Please email us at info@beyondthereefmexico.com');
+    alert('Could not send your request. Please email us directly at info@beyondthereefmexico.com');
   });
 }
 </script>

--- a/tour-chichen-itza.html
+++ b/tour-chichen-itza.html
@@ -613,25 +613,28 @@ function subBk(){
   var date  = document.getElementById('bkDate')  && document.getElementById('bkDate').value  || 'TBD';
   var hotel = document.getElementById('bkHotel') && document.getElementById('bkHotel').value.trim() || 'N/A';
   var notes = document.getElementById('bkNotes') && document.getElementById('bkNotes').value.trim() || 'None';
-  var pInfo = (pricing[selPax] && selPax)
-    ? selPax + ' guests — $' + (pricing[selPax] * selPax) + ' USD total'
+  var guests = selPax || 1;
+  var pricePerPerson = (pricing && pricing[guests]) ? pricing[guests] : 0;
+  var pInfo = pricePerPerson
+    ? guests + ' guests — $' + (pricePerPerson * guests) + ' USD total ($' + pricePerPerson + '/person)'
     : 'Price on request';
   var btn = document.querySelector('.bk-sub');
   if(btn){ btn.disabled = true; btn.textContent = 'Sending…'; }
+  var fd = new FormData();
+  fd.append("_subject", "Booking Request: Chichén Itzá");
+  fd.append("_replyto", email);
+  fd.append("tour", "Chichén Itzá");
+  fd.append("email", email);
+  fd.append("name", name);
+  fd.append("phone", phone);
+  fd.append("date", date);
+  fd.append("hotel_pickup", hotel);
+  fd.append("guests_and_price", pInfo);
+  fd.append("special_notes", notes);
   fetch('https://formspree.io/f/xbdpbgkw', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
-    body: JSON.stringify({
-      _subject: "Booking: Chichén Itzá",
-      email: email,
-      name: name,
-      phone: phone,
-      date: date,
-      hotel: hotel,
-      pricing: pInfo,
-      notes: notes,
-      tour: "Chichén Itzá"
-    })
+    body: fd,
+    headers: { 'Accept': 'application/json' }
   })
   .then(function(res){ return res.json(); })
   .then(function(data){
@@ -642,12 +645,13 @@ function subBk(){
       if(form) form.style.display = 'none';
       if(suc)  suc.style.display  = 'block';
     } else {
-      alert('Something went wrong. Please try again or email us at info@beyondthereefmexico.com');
+      var errMsg = (data.errors && data.errors[0] && data.errors[0].message) || 'Unknown error';
+      alert('Submission error: ' + errMsg + '. Please email us at info@beyondthereefmexico.com');
     }
   })
-  .catch(function(){
+  .catch(function(err){
     if(btn){ btn.disabled = false; btn.textContent = 'Request to Book →'; }
-    alert('Could not send your request. Please email us at info@beyondthereefmexico.com');
+    alert('Could not send your request. Please email us directly at info@beyondthereefmexico.com');
   });
 }
 </script>

--- a/tour-coba.html
+++ b/tour-coba.html
@@ -613,25 +613,28 @@ function subBk(){
   var date  = document.getElementById('bkDate')  && document.getElementById('bkDate').value  || 'TBD';
   var hotel = document.getElementById('bkHotel') && document.getElementById('bkHotel').value.trim() || 'N/A';
   var notes = document.getElementById('bkNotes') && document.getElementById('bkNotes').value.trim() || 'None';
-  var pInfo = (pricing[selPax] && selPax)
-    ? selPax + ' guests — $' + (pricing[selPax] * selPax) + ' USD total'
+  var guests = selPax || 1;
+  var pricePerPerson = (pricing && pricing[guests]) ? pricing[guests] : 0;
+  var pInfo = pricePerPerson
+    ? guests + ' guests — $' + (pricePerPerson * guests) + ' USD total ($' + pricePerPerson + '/person)'
     : 'Price on request';
   var btn = document.querySelector('.bk-sub');
   if(btn){ btn.disabled = true; btn.textContent = 'Sending…'; }
+  var fd = new FormData();
+  fd.append("_subject", "Booking Request: Cobá Private Tour");
+  fd.append("_replyto", email);
+  fd.append("tour", "Cobá Private Tour");
+  fd.append("email", email);
+  fd.append("name", name);
+  fd.append("phone", phone);
+  fd.append("date", date);
+  fd.append("hotel_pickup", hotel);
+  fd.append("guests_and_price", pInfo);
+  fd.append("special_notes", notes);
   fetch('https://formspree.io/f/xbdpbgkw', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
-    body: JSON.stringify({
-      _subject: "Booking: Cobá Private Tour",
-      email: email,
-      name: name,
-      phone: phone,
-      date: date,
-      hotel: hotel,
-      pricing: pInfo,
-      notes: notes,
-      tour: "Cobá Private Tour"
-    })
+    body: fd,
+    headers: { 'Accept': 'application/json' }
   })
   .then(function(res){ return res.json(); })
   .then(function(data){
@@ -642,12 +645,13 @@ function subBk(){
       if(form) form.style.display = 'none';
       if(suc)  suc.style.display  = 'block';
     } else {
-      alert('Something went wrong. Please try again or email us at info@beyondthereefmexico.com');
+      var errMsg = (data.errors && data.errors[0] && data.errors[0].message) || 'Unknown error';
+      alert('Submission error: ' + errMsg + '. Please email us at info@beyondthereefmexico.com');
     }
   })
-  .catch(function(){
+  .catch(function(err){
     if(btn){ btn.disabled = false; btn.textContent = 'Request to Book →'; }
-    alert('Could not send your request. Please email us at info@beyondthereefmexico.com');
+    alert('Could not send your request. Please email us directly at info@beyondthereefmexico.com');
   });
 }
 </script>

--- a/tour-dolphin-turtle.html
+++ b/tour-dolphin-turtle.html
@@ -613,25 +613,28 @@ function subBk(){
   var date  = document.getElementById('bkDate')  && document.getElementById('bkDate').value  || 'TBD';
   var hotel = document.getElementById('bkHotel') && document.getElementById('bkHotel').value.trim() || 'N/A';
   var notes = document.getElementById('bkNotes') && document.getElementById('bkNotes').value.trim() || 'None';
-  var pInfo = (pricing[selPax] && selPax)
-    ? selPax + ' guests — $' + (pricing[selPax] * selPax) + ' USD total'
+  var guests = selPax || 1;
+  var pricePerPerson = (pricing && pricing[guests]) ? pricing[guests] : 0;
+  var pInfo = pricePerPerson
+    ? guests + ' guests — $' + (pricePerPerson * guests) + ' USD total ($' + pricePerPerson + '/person)'
     : 'Price on request';
   var btn = document.querySelector('.bk-sub');
   if(btn){ btn.disabled = true; btn.textContent = 'Sending…'; }
+  var fd = new FormData();
+  fd.append("_subject", "Booking Request: Dolphin Watching in Sian Ka'an");
+  fd.append("_replyto", email);
+  fd.append("tour", "Dolphin Watching in Sian Ka'an");
+  fd.append("email", email);
+  fd.append("name", name);
+  fd.append("phone", phone);
+  fd.append("date", date);
+  fd.append("hotel_pickup", hotel);
+  fd.append("guests_and_price", pInfo);
+  fd.append("special_notes", notes);
   fetch('https://formspree.io/f/xbdpbgkw', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
-    body: JSON.stringify({
-      _subject: "Booking: Dolphin Watching in Sian Ka'an",
-      email: email,
-      name: name,
-      phone: phone,
-      date: date,
-      hotel: hotel,
-      pricing: pInfo,
-      notes: notes,
-      tour: "Dolphin Watching in Sian Ka'an"
-    })
+    body: fd,
+    headers: { 'Accept': 'application/json' }
   })
   .then(function(res){ return res.json(); })
   .then(function(data){
@@ -642,12 +645,13 @@ function subBk(){
       if(form) form.style.display = 'none';
       if(suc)  suc.style.display  = 'block';
     } else {
-      alert('Something went wrong. Please try again or email us at info@beyondthereefmexico.com');
+      var errMsg = (data.errors && data.errors[0] && data.errors[0].message) || 'Unknown error';
+      alert('Submission error: ' + errMsg + '. Please email us at info@beyondthereefmexico.com');
     }
   })
-  .catch(function(){
+  .catch(function(err){
     if(btn){ btn.disabled = false; btn.textContent = 'Request to Book →'; }
-    alert('Could not send your request. Please email us at info@beyondthereefmexico.com');
+    alert('Could not send your request. Please email us directly at info@beyondthereefmexico.com');
   });
 }
 </script>

--- a/tour-fishing.html
+++ b/tour-fishing.html
@@ -722,25 +722,28 @@ function subBk(){
   var date  = document.getElementById('bkDate')  && document.getElementById('bkDate').value  || 'TBD';
   var hotel = document.getElementById('bkHotel') && document.getElementById('bkHotel').value.trim() || 'N/A';
   var notes = document.getElementById('bkNotes') && document.getElementById('bkNotes').value.trim() || 'None';
-  var pInfo = (pricing[selPax] && selPax)
-    ? selPax + ' guests — $' + (pricing[selPax] * selPax) + ' USD total'
+  var guests = selPax || 1;
+  var pricePerPerson = (pricing && pricing[guests]) ? pricing[guests] : 0;
+  var pInfo = pricePerPerson
+    ? guests + ' guests — $' + (pricePerPerson * guests) + ' USD total ($' + pricePerPerson + '/person)'
     : 'Price on request';
   var btn = document.querySelector('.bk-sub');
   if(btn){ btn.disabled = true; btn.textContent = 'Sending…'; }
+  var fd = new FormData();
+  fd.append("_subject", "Booking Request: Private Fishing Experience");
+  fd.append("_replyto", email);
+  fd.append("tour", "Private Fishing Experience");
+  fd.append("email", email);
+  fd.append("name", name);
+  fd.append("phone", phone);
+  fd.append("date", date);
+  fd.append("hotel_pickup", hotel);
+  fd.append("guests_and_price", pInfo);
+  fd.append("special_notes", notes);
   fetch('https://formspree.io/f/xbdpbgkw', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
-    body: JSON.stringify({
-      _subject: "Booking: Private Fishing Experience",
-      email: email,
-      name: name,
-      phone: phone,
-      date: date,
-      hotel: hotel,
-      pricing: pInfo,
-      notes: notes,
-      tour: "Private Fishing Experience"
-    })
+    body: fd,
+    headers: { 'Accept': 'application/json' }
   })
   .then(function(res){ return res.json(); })
   .then(function(data){
@@ -751,12 +754,13 @@ function subBk(){
       if(form) form.style.display = 'none';
       if(suc)  suc.style.display  = 'block';
     } else {
-      alert('Something went wrong. Please try again or email us at info@beyondthereefmexico.com');
+      var errMsg = (data.errors && data.errors[0] && data.errors[0].message) || 'Unknown error';
+      alert('Submission error: ' + errMsg + '. Please email us at info@beyondthereefmexico.com');
     }
   })
-  .catch(function(){
+  .catch(function(err){
     if(btn){ btn.disabled = false; btn.textContent = 'Request to Book →'; }
-    alert('Could not send your request. Please email us at info@beyondthereefmexico.com');
+    alert('Could not send your request. Please email us directly at info@beyondthereefmexico.com');
   });
 }
 </script>

--- a/tour-holbox-express.html
+++ b/tour-holbox-express.html
@@ -613,25 +613,28 @@ function subBk(){
   var date  = document.getElementById('bkDate')  && document.getElementById('bkDate').value  || 'TBD';
   var hotel = document.getElementById('bkHotel') && document.getElementById('bkHotel').value.trim() || 'N/A';
   var notes = document.getElementById('bkNotes') && document.getElementById('bkNotes').value.trim() || 'None';
-  var pInfo = (pricing[selPax] && selPax)
-    ? selPax + ' guests — $' + (pricing[selPax] * selPax) + ' USD total'
+  var guests = selPax || 1;
+  var pricePerPerson = (pricing && pricing[guests]) ? pricing[guests] : 0;
+  var pInfo = pricePerPerson
+    ? guests + ' guests — $' + (pricePerPerson * guests) + ' USD total ($' + pricePerPerson + '/person)'
     : 'Price on request';
   var btn = document.querySelector('.bk-sub');
   if(btn){ btn.disabled = true; btn.textContent = 'Sending…'; }
+  var fd = new FormData();
+  fd.append("_subject", "Booking Request: Holbox Experience");
+  fd.append("_replyto", email);
+  fd.append("tour", "Holbox Experience");
+  fd.append("email", email);
+  fd.append("name", name);
+  fd.append("phone", phone);
+  fd.append("date", date);
+  fd.append("hotel_pickup", hotel);
+  fd.append("guests_and_price", pInfo);
+  fd.append("special_notes", notes);
   fetch('https://formspree.io/f/xbdpbgkw', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
-    body: JSON.stringify({
-      _subject: "Booking: Holbox Experience",
-      email: email,
-      name: name,
-      phone: phone,
-      date: date,
-      hotel: hotel,
-      pricing: pInfo,
-      notes: notes,
-      tour: "Holbox Experience"
-    })
+    body: fd,
+    headers: { 'Accept': 'application/json' }
   })
   .then(function(res){ return res.json(); })
   .then(function(data){
@@ -642,12 +645,13 @@ function subBk(){
       if(form) form.style.display = 'none';
       if(suc)  suc.style.display  = 'block';
     } else {
-      alert('Something went wrong. Please try again or email us at info@beyondthereefmexico.com');
+      var errMsg = (data.errors && data.errors[0] && data.errors[0].message) || 'Unknown error';
+      alert('Submission error: ' + errMsg + '. Please email us at info@beyondthereefmexico.com');
     }
   })
-  .catch(function(){
+  .catch(function(err){
     if(btn){ btn.disabled = false; btn.textContent = 'Request to Book →'; }
-    alert('Could not send your request. Please email us at info@beyondthereefmexico.com');
+    alert('Could not send your request. Please email us directly at info@beyondthereefmexico.com');
   });
 }
 </script>

--- a/tour-shared-chichen.html
+++ b/tour-shared-chichen.html
@@ -713,25 +713,28 @@ function subBk(){
   if(date !== 'TBD' && isUnavailableTourDay(date)){ alert('This tour is not available on Mondays, Thursdays, or Sundays. Please choose another date.'); return; }
   var hotel = document.getElementById('bkHotel') && document.getElementById('bkHotel').value.trim() || 'N/A';
   var notes = document.getElementById('bkNotes') && document.getElementById('bkNotes').value.trim() || 'None';
-  var pInfo = (pricing[selPax] && selPax)
-    ? selPax + ' guests — $' + (pricing[selPax] * selPax) + ' USD total'
+  var guests = selPax || 1;
+  var pricePerPerson = (pricing && pricing[guests]) ? pricing[guests] : 0;
+  var pInfo = pricePerPerson
+    ? guests + ' guests — $' + (pricePerPerson * guests) + ' USD total ($' + pricePerPerson + '/person)'
     : 'Price on request';
   var btn = document.querySelector('.bk-sub');
   if(btn){ btn.disabled = true; btn.textContent = 'Sending…'; }
+  var fd = new FormData();
+  fd.append("_subject", "Booking Request: Chichen Itza and Cenote Adventure (Shared experience)");
+  fd.append("_replyto", email);
+  fd.append("tour", "Chichen Itza and Cenote Adventure (Shared experience)");
+  fd.append("email", email);
+  fd.append("name", name);
+  fd.append("phone", phone);
+  fd.append("date", date);
+  fd.append("hotel_pickup", hotel);
+  fd.append("guests_and_price", pInfo);
+  fd.append("special_notes", notes);
   fetch('https://formspree.io/f/xbdpbgkw', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
-    body: JSON.stringify({
-      _subject: "Booking: Chichen Itza and Cenote Adventure (Shared experience)",
-      email: email,
-      name: name,
-      phone: phone,
-      date: date,
-      hotel: hotel,
-      pricing: pInfo,
-      notes: notes,
-      tour: "Chichen Itza and Cenote Adventure (Shared experience)"
-    })
+    body: fd,
+    headers: { 'Accept': 'application/json' }
   })
   .then(function(res){ return res.json(); })
   .then(function(data){
@@ -742,12 +745,13 @@ function subBk(){
       if(form) form.style.display = 'none';
       if(suc)  suc.style.display  = 'block';
     } else {
-      alert('Something went wrong. Please try again or email us at info@beyondthereefmexico.com');
+      var errMsg = (data.errors && data.errors[0] && data.errors[0].message) || 'Unknown error';
+      alert('Submission error: ' + errMsg + '. Please email us at info@beyondthereefmexico.com');
     }
   })
-  .catch(function(){
+  .catch(function(err){
     if(btn){ btn.disabled = false; btn.textContent = 'Request to Book →'; }
-    alert('Could not send your request. Please email us at info@beyondthereefmexico.com');
+    alert('Could not send your request. Please email us directly at info@beyondthereefmexico.com');
   });
 }
 </script>

--- a/tour-shared-coba.html
+++ b/tour-shared-coba.html
@@ -713,25 +713,28 @@ function subBk(){
   if(date !== 'TBD' && !isAvailableCobaDay(date)){ alert('This tour is only available on Mondays and Thursdays. Please choose another date.'); return; }
   var hotel = document.getElementById('bkHotel') && document.getElementById('bkHotel').value.trim() || 'N/A';
   var notes = document.getElementById('bkNotes') && document.getElementById('bkNotes').value.trim() || 'None';
-  var pInfo = (pricing[selPax] && selPax)
-    ? selPax + ' guests — $' + (pricing[selPax] * selPax) + ' USD total'
+  var guests = selPax || 1;
+  var pricePerPerson = (pricing && pricing[guests]) ? pricing[guests] : 0;
+  var pInfo = pricePerPerson
+    ? guests + ' guests — $' + (pricePerPerson * guests) + ' USD total ($' + pricePerPerson + '/person)'
     : 'Price on request';
   var btn = document.querySelector('.bk-sub');
   if(btn){ btn.disabled = true; btn.textContent = 'Sending…'; }
+  var fd = new FormData();
+  fd.append("_subject", "Booking Request: Coba and Cenote Adventure (Shared experience)");
+  fd.append("_replyto", email);
+  fd.append("tour", "Coba and Cenote Adventure (Shared experience)");
+  fd.append("email", email);
+  fd.append("name", name);
+  fd.append("phone", phone);
+  fd.append("date", date);
+  fd.append("hotel_pickup", hotel);
+  fd.append("guests_and_price", pInfo);
+  fd.append("special_notes", notes);
   fetch('https://formspree.io/f/xbdpbgkw', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
-    body: JSON.stringify({
-      _subject: "Booking: Coba and Cenote Adventure (Shared experience)",
-      email: email,
-      name: name,
-      phone: phone,
-      date: date,
-      hotel: hotel,
-      pricing: pInfo,
-      notes: notes,
-      tour: "Coba and Cenote Adventure (Shared experience)"
-    })
+    body: fd,
+    headers: { 'Accept': 'application/json' }
   })
   .then(function(res){ return res.json(); })
   .then(function(data){
@@ -742,12 +745,13 @@ function subBk(){
       if(form) form.style.display = 'none';
       if(suc)  suc.style.display  = 'block';
     } else {
-      alert('Something went wrong. Please try again or email us at info@beyondthereefmexico.com');
+      var errMsg = (data.errors && data.errors[0] && data.errors[0].message) || 'Unknown error';
+      alert('Submission error: ' + errMsg + '. Please email us at info@beyondthereefmexico.com');
     }
   })
-  .catch(function(){
+  .catch(function(err){
     if(btn){ btn.disabled = false; btn.textContent = 'Request to Book →'; }
-    alert('Could not send your request. Please email us at info@beyondthereefmexico.com');
+    alert('Could not send your request. Please email us directly at info@beyondthereefmexico.com');
   });
 }
 </script>

--- a/tour-shared-holbox.html
+++ b/tour-shared-holbox.html
@@ -693,25 +693,28 @@ function subBk(){
   var date  = document.getElementById('bkDate')  && document.getElementById('bkDate').value  || 'TBD';
   var hotel = document.getElementById('bkHotel') && document.getElementById('bkHotel').value.trim() || 'N/A';
   var notes = document.getElementById('bkNotes') && document.getElementById('bkNotes').value.trim() || 'None';
-  var pInfo = (pricing[selPax] && selPax)
-    ? selPax + ' guests — $' + (pricing[selPax] * selPax) + ' USD total'
+  var guests = selPax || 1;
+  var pricePerPerson = (pricing && pricing[guests]) ? pricing[guests] : 0;
+  var pInfo = pricePerPerson
+    ? guests + ' guests — $' + (pricePerPerson * guests) + ' USD total ($' + pricePerPerson + '/person)'
     : 'Price on request';
   var btn = document.querySelector('.bk-sub');
   if(btn){ btn.disabled = true; btn.textContent = 'Sending…'; }
+  var fd = new FormData();
+  fd.append("_subject", "Booking Request: Holbox Day Adventure (Shared experience)");
+  fd.append("_replyto", email);
+  fd.append("tour", "Holbox Day Adventure (Shared experience)");
+  fd.append("email", email);
+  fd.append("name", name);
+  fd.append("phone", phone);
+  fd.append("date", date);
+  fd.append("hotel_pickup", hotel);
+  fd.append("guests_and_price", pInfo);
+  fd.append("special_notes", notes);
   fetch('https://formspree.io/f/xbdpbgkw', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
-    body: JSON.stringify({
-      _subject: "Booking: Holbox Day Adventure (Shared experience)",
-      email: email,
-      name: name,
-      phone: phone,
-      date: date,
-      hotel: hotel,
-      pricing: pInfo,
-      notes: notes,
-      tour: "Holbox Day Adventure (Shared experience)"
-    })
+    body: fd,
+    headers: { 'Accept': 'application/json' }
   })
   .then(function(res){ return res.json(); })
   .then(function(data){
@@ -722,12 +725,13 @@ function subBk(){
       if(form) form.style.display = 'none';
       if(suc)  suc.style.display  = 'block';
     } else {
-      alert('Something went wrong. Please try again or email us at info@beyondthereefmexico.com');
+      var errMsg = (data.errors && data.errors[0] && data.errors[0].message) || 'Unknown error';
+      alert('Submission error: ' + errMsg + '. Please email us at info@beyondthereefmexico.com');
     }
   })
-  .catch(function(){
+  .catch(function(err){
     if(btn){ btn.disabled = false; btn.textContent = 'Request to Book →'; }
-    alert('Could not send your request. Please email us at info@beyondthereefmexico.com');
+    alert('Could not send your request. Please email us directly at info@beyondthereefmexico.com');
   });
 }
 </script>

--- a/tour-shared-tulum.html
+++ b/tour-shared-tulum.html
@@ -693,25 +693,28 @@ function subBk(){
   var date  = document.getElementById('bkDate')  && document.getElementById('bkDate').value  || 'TBD';
   var hotel = document.getElementById('bkHotel') && document.getElementById('bkHotel').value.trim() || 'N/A';
   var notes = document.getElementById('bkNotes') && document.getElementById('bkNotes').value.trim() || 'None';
-  var pInfo = (pricing[selPax] && selPax)
-    ? selPax + ' guests — $' + (pricing[selPax] * selPax) + ' USD total'
+  var guests = selPax || 1;
+  var pricePerPerson = (pricing && pricing[guests]) ? pricing[guests] : 0;
+  var pInfo = pricePerPerson
+    ? guests + ' guests — $' + (pricePerPerson * guests) + ' USD total ($' + pricePerPerson + '/person)'
     : 'Price on request';
   var btn = document.querySelector('.bk-sub');
   if(btn){ btn.disabled = true; btn.textContent = 'Sending…'; }
+  var fd = new FormData();
+  fd.append("_subject", "Booking Request: Tulum, Cenote & Village (Shared experience)");
+  fd.append("_replyto", email);
+  fd.append("tour", "Tulum, Cenote & Village (Shared experience)");
+  fd.append("email", email);
+  fd.append("name", name);
+  fd.append("phone", phone);
+  fd.append("date", date);
+  fd.append("hotel_pickup", hotel);
+  fd.append("guests_and_price", pInfo);
+  fd.append("special_notes", notes);
   fetch('https://formspree.io/f/xbdpbgkw', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
-    body: JSON.stringify({
-      _subject: "Booking: Tulum, Cenote & Village (Shared experience)",
-      email: email,
-      name: name,
-      phone: phone,
-      date: date,
-      hotel: hotel,
-      pricing: pInfo,
-      notes: notes,
-      tour: "Tulum, Cenote & Village (Shared experience)"
-    })
+    body: fd,
+    headers: { 'Accept': 'application/json' }
   })
   .then(function(res){ return res.json(); })
   .then(function(data){
@@ -722,12 +725,13 @@ function subBk(){
       if(form) form.style.display = 'none';
       if(suc)  suc.style.display  = 'block';
     } else {
-      alert('Something went wrong. Please try again or email us at info@beyondthereefmexico.com');
+      var errMsg = (data.errors && data.errors[0] && data.errors[0].message) || 'Unknown error';
+      alert('Submission error: ' + errMsg + '. Please email us at info@beyondthereefmexico.com');
     }
   })
-  .catch(function(){
+  .catch(function(err){
     if(btn){ btn.disabled = false; btn.textContent = 'Request to Book →'; }
-    alert('Could not send your request. Please email us at info@beyondthereefmexico.com');
+    alert('Could not send your request. Please email us directly at info@beyondthereefmexico.com');
   });
 }
 </script>

--- a/tour-shared-turtles.html
+++ b/tour-shared-turtles.html
@@ -616,25 +616,28 @@ function subBk(){
   var date  = document.getElementById('bkDate')  && document.getElementById('bkDate').value  || 'TBD';
   var hotel = document.getElementById('bkHotel') && document.getElementById('bkHotel').value.trim() || 'N/A';
   var notes = document.getElementById('bkNotes') && document.getElementById('bkNotes').value.trim() || 'None';
-  var pInfo = (pricing[selPax] && selPax)
-    ? selPax + ' guests — $' + (pricing[selPax] * selPax) + ' USD total'
+  var guests = selPax || 1;
+  var pricePerPerson = (pricing && pricing[guests]) ? pricing[guests] : 0;
+  var pInfo = pricePerPerson
+    ? guests + ' guests — $' + (pricePerPerson * guests) + ' USD total ($' + pricePerPerson + '/person)'
     : 'Price on request';
   var btn = document.querySelector('.bk-sub');
   if(btn){ btn.disabled = true; btn.textContent = 'Sending…'; }
+  var fd = new FormData();
+  fd.append("_subject", "Booking Request: Snorkeling with Turtles and Cenote Adventure (Shared experience)");
+  fd.append("_replyto", email);
+  fd.append("tour", "Snorkeling with Turtles and Cenote Adventure (Shared experience)");
+  fd.append("email", email);
+  fd.append("name", name);
+  fd.append("phone", phone);
+  fd.append("date", date);
+  fd.append("hotel_pickup", hotel);
+  fd.append("guests_and_price", pInfo);
+  fd.append("special_notes", notes);
   fetch('https://formspree.io/f/xbdpbgkw', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
-    body: JSON.stringify({
-      _subject: "Booking: Snorkeling with Turtles and Cenote Adventure (Shared experience)",
-      email: email,
-      name: name,
-      phone: phone,
-      date: date,
-      hotel: hotel,
-      pricing: pInfo,
-      notes: notes,
-      tour: "Snorkeling with Turtles and Cenote Adventure (Shared experience)"
-    })
+    body: fd,
+    headers: { 'Accept': 'application/json' }
   })
   .then(function(res){ return res.json(); })
   .then(function(data){
@@ -645,12 +648,13 @@ function subBk(){
       if(form) form.style.display = 'none';
       if(suc)  suc.style.display  = 'block';
     } else {
-      alert('Something went wrong. Please try again or email us at info@beyondthereefmexico.com');
+      var errMsg = (data.errors && data.errors[0] && data.errors[0].message) || 'Unknown error';
+      alert('Submission error: ' + errMsg + '. Please email us at info@beyondthereefmexico.com');
     }
   })
-  .catch(function(){
+  .catch(function(err){
     if(btn){ btn.disabled = false; btn.textContent = 'Request to Book →'; }
-    alert('Could not send your request. Please email us at info@beyondthereefmexico.com');
+    alert('Could not send your request. Please email us directly at info@beyondthereefmexico.com');
   });
 }
 </script>

--- a/tour-tacos-tour.html
+++ b/tour-tacos-tour.html
@@ -613,25 +613,28 @@ function subBk(){
   var date  = document.getElementById('bkDate')  && document.getElementById('bkDate').value  || 'TBD';
   var hotel = document.getElementById('bkHotel') && document.getElementById('bkHotel').value.trim() || 'N/A';
   var notes = document.getElementById('bkNotes') && document.getElementById('bkNotes').value.trim() || 'None';
-  var pInfo = (pricing[selPax] && selPax)
-    ? selPax + ' guests — $' + (pricing[selPax] * selPax) + ' USD total'
+  var guests = selPax || 1;
+  var pricePerPerson = (pricing && pricing[guests]) ? pricing[guests] : 0;
+  var pInfo = pricePerPerson
+    ? guests + ' guests — $' + (pricePerPerson * guests) + ' USD total ($' + pricePerPerson + '/person)'
     : 'Price on request';
   var btn = document.querySelector('.bk-sub');
   if(btn){ btn.disabled = true; btn.textContent = 'Sending…'; }
+  var fd = new FormData();
+  fd.append("_subject", "Booking Request: Taco Night in Playa");
+  fd.append("_replyto", email);
+  fd.append("tour", "Taco Night in Playa");
+  fd.append("email", email);
+  fd.append("name", name);
+  fd.append("phone", phone);
+  fd.append("date", date);
+  fd.append("hotel_pickup", hotel);
+  fd.append("guests_and_price", pInfo);
+  fd.append("special_notes", notes);
   fetch('https://formspree.io/f/xbdpbgkw', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
-    body: JSON.stringify({
-      _subject: "Booking: Taco Night in Playa",
-      email: email,
-      name: name,
-      phone: phone,
-      date: date,
-      hotel: hotel,
-      pricing: pInfo,
-      notes: notes,
-      tour: "Taco Night in Playa"
-    })
+    body: fd,
+    headers: { 'Accept': 'application/json' }
   })
   .then(function(res){ return res.json(); })
   .then(function(data){
@@ -642,12 +645,13 @@ function subBk(){
       if(form) form.style.display = 'none';
       if(suc)  suc.style.display  = 'block';
     } else {
-      alert('Something went wrong. Please try again or email us at info@beyondthereefmexico.com');
+      var errMsg = (data.errors && data.errors[0] && data.errors[0].message) || 'Unknown error';
+      alert('Submission error: ' + errMsg + '. Please email us at info@beyondthereefmexico.com');
     }
   })
-  .catch(function(){
+  .catch(function(err){
     if(btn){ btn.disabled = false; btn.textContent = 'Request to Book →'; }
-    alert('Could not send your request. Please email us at info@beyondthereefmexico.com');
+    alert('Could not send your request. Please email us directly at info@beyondthereefmexico.com');
   });
 }
 </script>

--- a/tour-tulum-coba.html
+++ b/tour-tulum-coba.html
@@ -613,25 +613,28 @@ function subBk(){
   var date  = document.getElementById('bkDate')  && document.getElementById('bkDate').value  || 'TBD';
   var hotel = document.getElementById('bkHotel') && document.getElementById('bkHotel').value.trim() || 'N/A';
   var notes = document.getElementById('bkNotes') && document.getElementById('bkNotes').value.trim() || 'None';
-  var pInfo = (pricing[selPax] && selPax)
-    ? selPax + ' guests — $' + (pricing[selPax] * selPax) + ' USD total'
+  var guests = selPax || 1;
+  var pricePerPerson = (pricing && pricing[guests]) ? pricing[guests] : 0;
+  var pInfo = pricePerPerson
+    ? guests + ' guests — $' + (pricePerPerson * guests) + ' USD total ($' + pricePerPerson + '/person)'
     : 'Price on request';
   var btn = document.querySelector('.bk-sub');
   if(btn){ btn.disabled = true; btn.textContent = 'Sending…'; }
+  var fd = new FormData();
+  fd.append("_subject", "Booking Request: Tulum + Cobá");
+  fd.append("_replyto", email);
+  fd.append("tour", "Tulum + Cobá");
+  fd.append("email", email);
+  fd.append("name", name);
+  fd.append("phone", phone);
+  fd.append("date", date);
+  fd.append("hotel_pickup", hotel);
+  fd.append("guests_and_price", pInfo);
+  fd.append("special_notes", notes);
   fetch('https://formspree.io/f/xbdpbgkw', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
-    body: JSON.stringify({
-      _subject: "Booking: Tulum + Cobá",
-      email: email,
-      name: name,
-      phone: phone,
-      date: date,
-      hotel: hotel,
-      pricing: pInfo,
-      notes: notes,
-      tour: "Tulum + Cobá"
-    })
+    body: fd,
+    headers: { 'Accept': 'application/json' }
   })
   .then(function(res){ return res.json(); })
   .then(function(data){
@@ -642,12 +645,13 @@ function subBk(){
       if(form) form.style.display = 'none';
       if(suc)  suc.style.display  = 'block';
     } else {
-      alert('Something went wrong. Please try again or email us at info@beyondthereefmexico.com');
+      var errMsg = (data.errors && data.errors[0] && data.errors[0].message) || 'Unknown error';
+      alert('Submission error: ' + errMsg + '. Please email us at info@beyondthereefmexico.com');
     }
   })
-  .catch(function(){
+  .catch(function(err){
     if(btn){ btn.disabled = false; btn.textContent = 'Request to Book →'; }
-    alert('Could not send your request. Please email us at info@beyondthereefmexico.com');
+    alert('Could not send your request. Please email us directly at info@beyondthereefmexico.com');
   });
 }
 </script>

--- a/tour-tulum-express.html
+++ b/tour-tulum-express.html
@@ -613,25 +613,28 @@ function subBk(){
   var date  = document.getElementById('bkDate')  && document.getElementById('bkDate').value  || 'TBD';
   var hotel = document.getElementById('bkHotel') && document.getElementById('bkHotel').value.trim() || 'N/A';
   var notes = document.getElementById('bkNotes') && document.getElementById('bkNotes').value.trim() || 'None';
-  var pInfo = (pricing[selPax] && selPax)
-    ? selPax + ' guests — $' + (pricing[selPax] * selPax) + ' USD total'
+  var guests = selPax || 1;
+  var pricePerPerson = (pricing && pricing[guests]) ? pricing[guests] : 0;
+  var pInfo = pricePerPerson
+    ? guests + ' guests — $' + (pricePerPerson * guests) + ' USD total ($' + pricePerPerson + '/person)'
     : 'Price on request';
   var btn = document.querySelector('.bk-sub');
   if(btn){ btn.disabled = true; btn.textContent = 'Sending…'; }
+  var fd = new FormData();
+  fd.append("_subject", "Booking Request: Tulum Highlights");
+  fd.append("_replyto", email);
+  fd.append("tour", "Tulum Highlights");
+  fd.append("email", email);
+  fd.append("name", name);
+  fd.append("phone", phone);
+  fd.append("date", date);
+  fd.append("hotel_pickup", hotel);
+  fd.append("guests_and_price", pInfo);
+  fd.append("special_notes", notes);
   fetch('https://formspree.io/f/xbdpbgkw', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
-    body: JSON.stringify({
-      _subject: "Booking: Tulum Highlights",
-      email: email,
-      name: name,
-      phone: phone,
-      date: date,
-      hotel: hotel,
-      pricing: pInfo,
-      notes: notes,
-      tour: "Tulum Highlights"
-    })
+    body: fd,
+    headers: { 'Accept': 'application/json' }
   })
   .then(function(res){ return res.json(); })
   .then(function(data){
@@ -642,12 +645,13 @@ function subBk(){
       if(form) form.style.display = 'none';
       if(suc)  suc.style.display  = 'block';
     } else {
-      alert('Something went wrong. Please try again or email us at info@beyondthereefmexico.com');
+      var errMsg = (data.errors && data.errors[0] && data.errors[0].message) || 'Unknown error';
+      alert('Submission error: ' + errMsg + '. Please email us at info@beyondthereefmexico.com');
     }
   })
-  .catch(function(){
+  .catch(function(err){
     if(btn){ btn.disabled = false; btn.textContent = 'Request to Book →'; }
-    alert('Could not send your request. Please email us at info@beyondthereefmexico.com');
+    alert('Could not send your request. Please email us directly at info@beyondthereefmexico.com');
   });
 }
 </script>

--- a/tour-tulum-underwater.html
+++ b/tour-tulum-underwater.html
@@ -613,25 +613,28 @@ function subBk(){
   var date  = document.getElementById('bkDate')  && document.getElementById('bkDate').value  || 'TBD';
   var hotel = document.getElementById('bkHotel') && document.getElementById('bkHotel').value.trim() || 'N/A';
   var notes = document.getElementById('bkNotes') && document.getElementById('bkNotes').value.trim() || 'None';
-  var pInfo = (pricing[selPax] && selPax)
-    ? selPax + ' guests — $' + (pricing[selPax] * selPax) + ' USD total'
+  var guests = selPax || 1;
+  var pricePerPerson = (pricing && pricing[guests]) ? pricing[guests] : 0;
+  var pInfo = pricePerPerson
+    ? guests + ' guests — $' + (pricePerPerson * guests) + ' USD total ($' + pricePerPerson + '/person)'
     : 'Price on request';
   var btn = document.querySelector('.bk-sub');
   if(btn){ btn.disabled = true; btn.textContent = 'Sending…'; }
+  var fd = new FormData();
+  fd.append("_subject", "Booking Request: Tulum Snorkeling Experience");
+  fd.append("_replyto", email);
+  fd.append("tour", "Tulum Snorkeling Experience");
+  fd.append("email", email);
+  fd.append("name", name);
+  fd.append("phone", phone);
+  fd.append("date", date);
+  fd.append("hotel_pickup", hotel);
+  fd.append("guests_and_price", pInfo);
+  fd.append("special_notes", notes);
   fetch('https://formspree.io/f/xbdpbgkw', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
-    body: JSON.stringify({
-      _subject: "Booking: Tulum Snorkeling Experience",
-      email: email,
-      name: name,
-      phone: phone,
-      date: date,
-      hotel: hotel,
-      pricing: pInfo,
-      notes: notes,
-      tour: "Tulum Snorkeling Experience"
-    })
+    body: fd,
+    headers: { 'Accept': 'application/json' }
   })
   .then(function(res){ return res.json(); })
   .then(function(data){
@@ -642,12 +645,13 @@ function subBk(){
       if(form) form.style.display = 'none';
       if(suc)  suc.style.display  = 'block';
     } else {
-      alert('Something went wrong. Please try again or email us at info@beyondthereefmexico.com');
+      var errMsg = (data.errors && data.errors[0] && data.errors[0].message) || 'Unknown error';
+      alert('Submission error: ' + errMsg + '. Please email us at info@beyondthereefmexico.com');
     }
   })
-  .catch(function(){
+  .catch(function(err){
     if(btn){ btn.disabled = false; btn.textContent = 'Request to Book →'; }
-    alert('Could not send your request. Please email us at info@beyondthereefmexico.com');
+    alert('Could not send your request. Please email us directly at info@beyondthereefmexico.com');
   });
 }
 </script>

--- a/tour-turtles-cenotes.html
+++ b/tour-turtles-cenotes.html
@@ -613,25 +613,28 @@ function subBk(){
   var date  = document.getElementById('bkDate')  && document.getElementById('bkDate').value  || 'TBD';
   var hotel = document.getElementById('bkHotel') && document.getElementById('bkHotel').value.trim() || 'N/A';
   var notes = document.getElementById('bkNotes') && document.getElementById('bkNotes').value.trim() || 'None';
-  var pInfo = (pricing[selPax] && selPax)
-    ? selPax + ' guests — $' + (pricing[selPax] * selPax) + ' USD total'
+  var guests = selPax || 1;
+  var pricePerPerson = (pricing && pricing[guests]) ? pricing[guests] : 0;
+  var pInfo = pricePerPerson
+    ? guests + ' guests — $' + (pricePerPerson * guests) + ' USD total ($' + pricePerPerson + '/person)'
     : 'Price on request';
   var btn = document.querySelector('.bk-sub');
   if(btn){ btn.disabled = true; btn.textContent = 'Sending…'; }
+  var fd = new FormData();
+  fd.append("_subject", "Booking Request: Sea Turtle and Cenote Snorkeling Experience");
+  fd.append("_replyto", email);
+  fd.append("tour", "Sea Turtle and Cenote Snorkeling Experience");
+  fd.append("email", email);
+  fd.append("name", name);
+  fd.append("phone", phone);
+  fd.append("date", date);
+  fd.append("hotel_pickup", hotel);
+  fd.append("guests_and_price", pInfo);
+  fd.append("special_notes", notes);
   fetch('https://formspree.io/f/xbdpbgkw', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
-    body: JSON.stringify({
-      _subject: "Booking: Sea Turtle and Cenote Snorkeling Experience",
-      email: email,
-      name: name,
-      phone: phone,
-      date: date,
-      hotel: hotel,
-      pricing: pInfo,
-      notes: notes,
-      tour: "Sea Turtle and Cenote Snorkeling Experience"
-    })
+    body: fd,
+    headers: { 'Accept': 'application/json' }
   })
   .then(function(res){ return res.json(); })
   .then(function(data){
@@ -642,12 +645,13 @@ function subBk(){
       if(form) form.style.display = 'none';
       if(suc)  suc.style.display  = 'block';
     } else {
-      alert('Something went wrong. Please try again or email us at info@beyondthereefmexico.com');
+      var errMsg = (data.errors && data.errors[0] && data.errors[0].message) || 'Unknown error';
+      alert('Submission error: ' + errMsg + '. Please email us at info@beyondthereefmexico.com');
     }
   })
-  .catch(function(){
+  .catch(function(err){
     if(btn){ btn.disabled = false; btn.textContent = 'Request to Book →'; }
-    alert('Could not send your request. Please email us at info@beyondthereefmexico.com');
+    alert('Could not send your request. Please email us directly at info@beyondthereefmexico.com');
   });
 }
 </script>


### PR DESCRIPTION
JSON submissions to Formspree can silently fail if the form hasn't been activated yet (Formspree sends an activation email on first submission). FormData (multipart/form-data) is the classic Formspree approach and is more reliable across all form states.

Changes per tour file:
- Use FormData + fd.append() instead of JSON.stringify()
- Drop Content-Type header (browser sets it automatically for FormData)
- Add _replyto field so Michael can reply directly to the customer's email
- Add _subject with tour name for clear email subject lines
- Show actual Formspree error message in the alert if submission is rejected
- Guests/price formatting now shows per-person rate alongside total

https://claude.ai/code/session_017SqDj92BtR8ccVNB5DzJNM