### PR TITLE
Update Our Story copy, highlight “More”, simplify values section and add CTA

### DIFF
--- a/our-story.html
+++ b/our-story.html
@@ -366,13 +366,16 @@ footer{background:var(--navy);padding:52px 20px 28px;color:rgba(255,255,255,.52)
   <div style="display:grid;grid-template-columns:1fr;gap:32px;align-items:center;max-width:900px;margin:0 auto">
     <div>
       <div id="storyWhoLbl" class="lbl">Who We Are</div>
-      <h2 id="storyWhoH2" class="h2">More than a tour company.</h2>
-      <p id="storyWhoP1" style="font-size:15px;line-height:1.82;color:var(--muted);margin-bottom:16px">Beyond the Reef Mexico is more than a tour company. We create private experiences that let you feel the true Riviera Maya in a more personal, relaxed, and authentic way.</p>
-      <p id="storyWhoP2" style="font-size:15px;line-height:1.82;color:var(--muted);margin-bottom:16px">We are not about crowded attractions, rushed schedules, or one size fits all tours. We are about taking the time to do things right, giving every guest a more meaningful experience, and sharing places, flavors, and moments that feel real.</p>
-      <p id="storyWhoP3" style="font-size:15px;line-height:1.82;color:var(--muted);margin-bottom:16px">Our certified bilingual hosts have more than 10 years of experience and a deep connection to the region. From hidden cenotes and peaceful beaches to local food and ancient ruins, they know how to show you a side of the Riviera Maya that most visitors never truly experience.</p>
-      <p id="storyWhoP4" style="font-size:15px;line-height:1.82;color:var(--muted);margin-bottom:16px">We care deeply about the people we serve and the people we work with. That means thoughtful service, honest hospitality, and a team that is respected and fairly rewarded for the care they bring to every tour.</p>
-      <p id="storyWhoP5" style="font-size:15px;line-height:1.82;color:var(--muted);margin-bottom:16px">Whether you are snorkeling with sea turtles, discovering UNESCO World Heritage sites, heading out on a fishing charter, or enjoying an unforgettable taco tour, every detail is arranged with care so you can simply enjoy the moment.</p>
-      <p id="storyWhoP6" style="font-size:15px;line-height:1.82;color:var(--muted)">This is the Riviera Maya, without the rush.</p>
+      <h2 id="storyWhoH2" class="h2"><span style="color:var(--coral)">More</span> than a tour company.</h2>
+      <p id="storyWhoP1" style="font-size:15px;line-height:1.82;color:var(--muted);margin-bottom:16px">Beyond the Reef Mexico is more than a tour company. We create private experiences the way they should be done, unhurried, personal, and real.</p>
+      <p id="storyWhoP2" style="font-size:15px;line-height:1.82;color:var(--muted);margin-bottom:16px">With more than 14 years of experience in the Riviera Maya, we’ve seen how most experiences operate. Long pickups. Filling the bus. Rushed schedules. Crowds at every stop. That’s exactly what we built our company to avoid.</p>
+      <p id="storyWhoP3" style="font-size:15px;line-height:1.82;color:var(--muted);margin-bottom:16px">We don’t rush you, and we don’t design experiences around filling seats. We design them around you.</p>
+      <p id="storyWhoP4" style="font-size:15px;line-height:1.82;color:var(--muted);margin-bottom:16px">Yes, we offer some unique experiences, but we also offer many of the same places you’ll find anywhere else, turtles, cenotes, ruins. The difference is how we do it. Because booking something “private” doesn’t always mean you’ll actually feel alone once you arrive. Most of the time, you still end up sharing the water or the space with multiple groups. We work hard to change that.</p>
+      <p id="storyWhoP5" style="font-size:15px;line-height:1.82;color:var(--muted);margin-bottom:16px">Our goal is simple: fewer people, better timing, and real space to enjoy each moment. No swimming shoulder to shoulder with 5 other groups around the same turtle. No crowded cenotes where you’re just passing through. Just you, your people, and the experience as it was meant to be.</p>
+      <p id="storyWhoP6" style="font-size:15px;line-height:1.82;color:var(--muted);margin-bottom:16px">Our certified bilingual hosts bring years of local knowledge and a real connection to this place. From hidden cenotes and quiet beaches to authentic food and ancient ruins, they know how to show you a side of the Riviera Maya that feels natural, not staged.</p>
+      <p style="font-size:15px;line-height:1.82;color:var(--muted);margin-bottom:16px">We also believe how things are done matters. We take care of our team, we respect the places we visit, and we focus on honest, thoughtful service from start to finish.</p>
+      <p style="font-size:15px;line-height:1.82;color:var(--muted);margin-bottom:16px">This is the Riviera Maya, done differently.</p>
+      <p style="font-size:15px;line-height:1.82;color:var(--muted)">No rush. No crowds. Just the way it should be.</p>
     </div>
     <div style="background:linear-gradient(135deg,var(--navy),var(--teal));border-radius:var(--r3);padding:40px 32px;color:#fff;text-align:center">
       <div style="font-size:52px;font-weight:900;color:var(--gold);line-height:1;margin-bottom:4px">14+</div>
@@ -386,17 +389,7 @@ footer{background:var(--navy);padding:52px 20px 28px;color:rgba(255,255,255,.52)
   </div>
 </section>
 <section class="sec" style="background:#FFF8E7;text-align:center">
-  <div id="storyValLbl" class="lbl">Our Values</div>
-  <h2 id="storyValH2" class="h2">What makes us different.</h2>
-  <div style="max-width:860px;margin:0 auto 28px">
-    <h3 id="storyValH3" style="font-size:26px;font-weight:900;color:var(--navy);margin-bottom:14px">More Than a Day Out</h3>
-    <p id="storyValP1" style="font-size:15px;line-height:1.82;color:var(--muted);margin-bottom:12px">Some experiences are rushed.</p>
-    <p id="storyValP2" style="font-size:15px;line-height:1.82;color:var(--muted);margin-bottom:12px">Some feel crowded.</p>
-    <p id="storyValP3" style="font-size:15px;line-height:1.82;color:var(--muted);margin-bottom:12px">Some feel like everyone gets the exact same thing.</p>
-    <p id="storyValP4" style="font-size:15px;line-height:1.82;color:var(--muted);margin-bottom:12px">That is not how we do it.</p>
-    <p id="storyValP5" style="font-size:15px;line-height:1.82;color:var(--muted)">We believe the Riviera Maya is best experienced slowly, personally, and with real care. Whether you choose one of our signature private experiences or build your own custom adventure, our goal is always the same: to make you feel welcome, looked after, and truly connected to this place.</p>
-  </div>
-  <h3 id="storyWhyH3" style="font-size:24px;font-weight:900;color:var(--navy);margin-bottom:18px">Why Guests Choose Us</h3>
+  <h2 id="storyWhyH3" class="h2" style="margin-bottom:18px">Why Guests Choose Us</h2>
   <div style="display:grid;grid-template-columns:1fr;gap:16px;max-width:800px;margin:0 auto">
     <div style="background:#fff;border-radius:var(--r2);padding:24px;border:1.5px solid var(--border);box-shadow:var(--sh);text-align:left"><h4 id="storyWhy1H" style="font-size:16px;font-weight:800;margin-bottom:8px">Because care matters</h4><p id="storyWhy1P" style="font-size:13px;color:var(--muted);line-height:1.7">Your safety, comfort, and peace of mind come first. Every detail is carefully planned so you can relax and enjoy the experience fully.</p></div>
     <div style="background:#fff;border-radius:var(--r2);padding:24px;border:1.5px solid var(--border);box-shadow:var(--sh);text-align:left"><h4 id="storyWhy2H" style="font-size:16px;font-weight:800;margin-bottom:8px">Because the moment matters</h4><p id="storyWhy2P" style="font-size:13px;color:var(--muted);line-height:1.7">Professional photos are included with every private experience, so you can stay present and leave with real memories that last.</p></div>
@@ -406,6 +399,7 @@ footer{background:var(--navy);padding:52px 20px 28px;color:rgba(255,255,255,.52)
   <div style="max-width:800px;margin:28px auto 0">
     <h3 id="storyReadyH3" style="font-size:24px;font-weight:900;color:var(--navy);margin-bottom:12px">Ready to experience the Riviera Maya differently?</h3>
     <p id="storyReadyP" style="font-size:15px;line-height:1.82;color:var(--muted)">Choose a private experience designed around you, or build your own custom adventure that still feels personal, thoughtful, and full of heart.</p>
+    <a href="https://wa.me/529841670697" class="btn btn-coral btn-md" target="_blank" rel="noopener" style="margin-top:16px">Book Now</a>
   </div>
 </section>
 <footer>


### PR DESCRIPTION
### Motivation
- Improve the main "Who We Are" messaging to the supplied, longer copy that emphasizes private, unhurried experiences.
- Make the word "More" visually prominent in the heading to match the brand tone.
- Simplify the page structure by removing the redundant "Our Values / More Than a Day Out" block and surface "Why Guests Choose Us" as the section title to focus attention.
- Add a clear booking call-to-action under the final section to improve conversions.

### Description
- Updated the `More than a tour company.` heading to highlight the word `More` in orange (`var(--coral)`).
- Replaced the entire "Who We Are" paragraph block with the provided long-form copy (unhurried, personal, real, 14+ years, host details, etc.) in `our-story.html`.
- Removed the old "Our Values / What makes us different / More Than a Day Out" content block from `our-story.html` and promoted the existing reasons cards under the single section titled `Why Guests Choose Us`.
- Added a `Book Now` CTA button (`<a href="https://wa.me/529841670697" class="btn btn-coral btn-md">Book Now</a>`) beneath the paragraph with id `storyReadyP`.

### Testing
- Verified the updated text and structure using `rg -n "storyWhoH2|storyWhoP1|No rush\. No crowds|Why Guests Choose Us|Book Now" our-story.html`, which found the new heading, new copy, the closing tagline, promoted section title, and CTA.
- Inspected the output region of the file with `nl -ba our-story.html | sed -n '360,420p'` to confirm the inserted paragraphs and CTA anchor appear in the expected place.
- No automated unit test suite is configured for this static HTML change. Everything above is a successful file-level verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea8f031d24833082e9411d6308c8a4)