### PR TITLE
Add 'Go Beyond the Lens' video section to Private Experiences

### DIFF
--- a/index.html
+++ b/index.html
@@ -253,14 +253,15 @@ button{font-family:inherit;cursor:pointer;border:none;background:none}
 
 
 /* GO BEYOND THE LENS */
-.lens-wrap{max-width:1120px;margin:0 auto 28px;text-align:left}
-.lens-head{text-align:center;margin-bottom:20px}
-.lens-head .sub{max-width:620px;margin:0 auto}
+.lens-sec{background:#123E63;text-align:center;padding-top:92px;padding-bottom:104px}
+.lens-wrap{max-width:1120px;margin:0 auto;text-align:center}
+.lens-head{text-align:center;margin-bottom:28px}
+.lens-head .sub{max-width:620px;margin:0 auto;color:rgba(255,255,255,.82)}
 .lens-grid{display:grid;grid-template-columns:1fr;gap:16px}
-.lens-card{background:#fff;border:1.5px solid var(--border);border-radius:var(--r2);padding:16px;box-shadow:var(--sh)}
-.lens-card h3{font-size:20px;font-weight:800;letter-spacing:-.02em;margin-bottom:10px;color:var(--ink)}
+.lens-card{background:#fff;border:1.5px solid var(--border);border-radius:var(--r2);padding:16px;box-shadow:var(--sh);text-align:center}
+.lens-card h3{font-size:20px;font-weight:800;letter-spacing:-.02em;margin-bottom:10px;color:var(--ink);text-align:center}
 .lens-video{width:100%;aspect-ratio:16/9;border:0;border-radius:12px;background:#0E2A45;display:block}
-.lens-card p{margin-top:12px;font-size:14px;line-height:1.7;color:var(--muted)}
+.lens-card p{margin-top:12px;font-size:14px;line-height:1.7;color:var(--muted);text-align:center}
 @media(min-width:900px){.lens-grid{grid-template-columns:1fr 1fr}.lens-card{padding:18px}}
 
 /* SLIDER */
@@ -662,20 +663,21 @@ Just you, your people, and a carefully designed experience</p>
 </section>
 
 <!-- GO BEYOND THE LENS -->
-<section class="sec" style="background:#EAF4FF;text-align:center;padding-top:24px">
+<section class="sec lens-sec">
   <div class="lens-wrap">
+    <div class="lbl lbl-white">Real POV. No Crowds. Just You</div>
     <div class="lens-head">
-      <h2 class="h2"><span style="color:var(--coral)">Go beyond</span> the Lens</h2>
+      <h2 class="h2 h2-white"><span style="color:var(--coral)">Go beyond</span> the Lens</h2>
       <p class="sub">Most tours show you places.<br>We make sure you actually feel them.</p>
     </div>
     <div class="lens-grid">
       <article class="lens-card">
-        <h3>Step Into the Hidden Underground</h3>
+        <h3>🔦 Step Into the Hidden Underground</h3>
         <iframe class="lens-video" title="Step Into the Hidden Underground" src="https://player.vimeo.com/video/1186385310?h=f7cb7ced82" loading="lazy" referrerpolicy="strict-origin-when-cross-origin" allow="autoplay; fullscreen; picture-in-picture; clipboard-write; encrypted-media; web-share" allowfullscreen></iframe>
         <p>No lines. No noise.<br>Just you, your people, and a hidden world beneath the jungle.<br>Swim through crystal-clear water, walk through ancient formations, and feel the silence most travelers never experience.</p>
       </article>
       <article class="lens-card">
-        <h3>Eat Where It’s Real</h3>
+        <h3>🌮 Eat Where It’s Real</h3>
         <iframe class="lens-video" title="Eat Where It’s Real" src="https://player.vimeo.com/video/1186396922?h=0f8cd51077" loading="lazy" referrerpolicy="strict-origin-when-cross-origin" allow="autoplay; fullscreen; picture-in-picture; clipboard-write; encrypted-media; web-share" allowfullscreen></iframe>
         <p>Fresh handmade tortillas, cooked right in front of you.<br>Over 20 authentic flavors prepared the traditional way.<br>No tourist stops. Just real local food, shared the way it should be.</p>
       </article>

--- a/index.html
+++ b/index.html
@@ -454,25 +454,6 @@ Just you, your people, and a carefully designed experience</p>
   <div id="privLbl" class="lbl">Private Experiences</div>
   <h2 id="privH2" class="h2">Our Top Experiences, <span style="color:var(--coral)">Made Around You</span></h2>
   <p id="privSub" class="sub" style="margin:0 auto 24px">Only you and your group. No rush, no shared groups, just a more personal Riviera Maya experience at your own pace.</p>
-
-  <div class="lens-wrap">
-    <div class="lens-head">
-      <h3 class="h2"><span style="color:var(--coral)">Go beyond</span> the Lens</h3>
-      <p class="sub">Most tours show you places.<br>We make sure you actually feel them.</p>
-    </div>
-    <div class="lens-grid">
-      <article class="lens-card">
-        <h3>Step Into the Hidden Underground</h3>
-        <iframe class="lens-video" title="Step Into the Hidden Underground" src="https://player.vimeo.com/video/1186385310?h=f7cb7ced82" loading="lazy" referrerpolicy="strict-origin-when-cross-origin" allow="autoplay; fullscreen; picture-in-picture; clipboard-write; encrypted-media; web-share" allowfullscreen></iframe>
-        <p>No lines. No noise.<br>Just you, your people, and a hidden world beneath the jungle.<br>Swim through crystal-clear water, walk through ancient formations, and feel the silence most travelers never experience.</p>
-      </article>
-      <article class="lens-card">
-        <h3>Eat Where It’s Real</h3>
-        <iframe class="lens-video" title="Eat Where It’s Real" src="https://player.vimeo.com/video/1186396922?h=0f8cd51077" loading="lazy" referrerpolicy="strict-origin-when-cross-origin" allow="autoplay; fullscreen; picture-in-picture; clipboard-write; encrypted-media; web-share" allowfullscreen></iframe>
-        <p>Fresh handmade tortillas, cooked right in front of you.<br>Over 20 authentic flavors prepared the traditional way.<br>No tourist stops. Just real local food, shared the way it should be.</p>
-      </article>
-    </div>
-  </div>
   <div class="sl-outer">
     <div class="sl-viewport">
       <div class="sl-track" id="privTrack"><article class="tc">
@@ -677,6 +658,28 @@ Just you, your people, and a carefully designed experience</p>
   </div>
   <div style="text-align:center;padding:28px 0 0">
     <a href="tours.html" class="btn btn-navy btn-md" data-i18n="c.btn.viewall">View All Experiences →</a>
+  </div>
+</section>
+
+<!-- GO BEYOND THE LENS -->
+<section class="sec" style="background:#ffffff;text-align:center;padding-top:24px">
+  <div class="lens-wrap">
+    <div class="lens-head">
+      <h2 class="h2"><span style="color:var(--coral)">Go beyond</span> the Lens</h2>
+      <p class="sub">Most tours show you places.<br>We make sure you actually feel them.</p>
+    </div>
+    <div class="lens-grid">
+      <article class="lens-card">
+        <h3>Step Into the Hidden Underground</h3>
+        <iframe class="lens-video" title="Step Into the Hidden Underground" src="https://player.vimeo.com/video/1186385310?h=f7cb7ced82" loading="lazy" referrerpolicy="strict-origin-when-cross-origin" allow="autoplay; fullscreen; picture-in-picture; clipboard-write; encrypted-media; web-share" allowfullscreen></iframe>
+        <p>No lines. No noise.<br>Just you, your people, and a hidden world beneath the jungle.<br>Swim through crystal-clear water, walk through ancient formations, and feel the silence most travelers never experience.</p>
+      </article>
+      <article class="lens-card">
+        <h3>Eat Where It’s Real</h3>
+        <iframe class="lens-video" title="Eat Where It’s Real" src="https://player.vimeo.com/video/1186396922?h=0f8cd51077" loading="lazy" referrerpolicy="strict-origin-when-cross-origin" allow="autoplay; fullscreen; picture-in-picture; clipboard-write; encrypted-media; web-share" allowfullscreen></iframe>
+        <p>Fresh handmade tortillas, cooked right in front of you.<br>Over 20 authentic flavors prepared the traditional way.<br>No tourist stops. Just real local food, shared the way it should be.</p>
+      </article>
+    </div>
   </div>
 </section>
 

--- a/index.html
+++ b/index.html
@@ -250,6 +250,19 @@ button{font-family:inherit;cursor:pointer;border:none;background:none}
 .values-sec .wc{flex-direction:column;align-items:center;text-align:center}
 .values-sec .wi{margin-bottom:2px}
 
+
+
+/* GO BEYOND THE LENS */
+.lens-wrap{max-width:1120px;margin:0 auto 28px;text-align:left}
+.lens-head{text-align:center;margin-bottom:20px}
+.lens-head .sub{max-width:620px;margin:0 auto}
+.lens-grid{display:grid;grid-template-columns:1fr;gap:16px}
+.lens-card{background:#fff;border:1.5px solid var(--border);border-radius:var(--r2);padding:16px;box-shadow:var(--sh)}
+.lens-card h3{font-size:20px;font-weight:800;letter-spacing:-.02em;margin-bottom:10px;color:var(--ink)}
+.lens-video{width:100%;aspect-ratio:16/9;border:0;border-radius:12px;background:#0E2A45;display:block}
+.lens-card p{margin-top:12px;font-size:14px;line-height:1.7;color:var(--muted)}
+@media(min-width:900px){.lens-grid{grid-template-columns:1fr 1fr}.lens-card{padding:18px}}
+
 /* SLIDER */
 .sl-outer{overflow:hidden}.sl-viewport{overflow:hidden}
 .sl-track{display:flex;gap:16px;padding:8px 20px 24px;transition:transform .42s cubic-bezier(.4,0,.2,1);will-change:transform;align-items:stretch}
@@ -441,6 +454,25 @@ Just you, your people, and a carefully designed experience</p>
   <div id="privLbl" class="lbl">Private Experiences</div>
   <h2 id="privH2" class="h2">Our Top Experiences, <span style="color:var(--coral)">Made Around You</span></h2>
   <p id="privSub" class="sub" style="margin:0 auto 24px">Only you and your group. No rush, no shared groups, just a more personal Riviera Maya experience at your own pace.</p>
+
+  <div class="lens-wrap">
+    <div class="lens-head">
+      <h3 class="h2"><span style="color:var(--coral)">Go beyond</span> the Lens</h3>
+      <p class="sub">Most tours show you places.<br>We make sure you actually feel them.</p>
+    </div>
+    <div class="lens-grid">
+      <article class="lens-card">
+        <h3>Step Into the Hidden Underground</h3>
+        <iframe class="lens-video" title="Step Into the Hidden Underground" src="https://player.vimeo.com/video/1186385310?h=f7cb7ced82" loading="lazy" referrerpolicy="strict-origin-when-cross-origin" allow="autoplay; fullscreen; picture-in-picture; clipboard-write; encrypted-media; web-share" allowfullscreen></iframe>
+        <p>No lines. No noise.<br>Just you, your people, and a hidden world beneath the jungle.<br>Swim through crystal-clear water, walk through ancient formations, and feel the silence most travelers never experience.</p>
+      </article>
+      <article class="lens-card">
+        <h3>Eat Where It’s Real</h3>
+        <iframe class="lens-video" title="Eat Where It’s Real" src="https://player.vimeo.com/video/1186396922?h=0f8cd51077" loading="lazy" referrerpolicy="strict-origin-when-cross-origin" allow="autoplay; fullscreen; picture-in-picture; clipboard-write; encrypted-media; web-share" allowfullscreen></iframe>
+        <p>Fresh handmade tortillas, cooked right in front of you.<br>Over 20 authentic flavors prepared the traditional way.<br>No tourist stops. Just real local food, shared the way it should be.</p>
+      </article>
+    </div>
+  </div>
   <div class="sl-outer">
     <div class="sl-viewport">
       <div class="sl-track" id="privTrack"><article class="tc">

--- a/index.html
+++ b/index.html
@@ -662,7 +662,7 @@ Just you, your people, and a carefully designed experience</p>
 </section>
 
 <!-- GO BEYOND THE LENS -->
-<section class="sec" style="background:#ffffff;text-align:center;padding-top:24px">
+<section class="sec" style="background:#EAF4FF;text-align:center;padding-top:24px">
   <div class="lens-wrap">
     <div class="lens-head">
       <h2 class="h2"><span style="color:var(--coral)">Go beyond</span> the Lens</h2>


### PR DESCRIPTION
### Motivation
- Surface two short experiential videos under the Private Experiences heading to communicate the "feel" of the tours, with the phrase `Go beyond` emphasized in orange.  
- Ensure videos do not slow initial page load by deferring embed loading and requiring user-initiated playback.

### Description
- Added a new HTML block before the private tours slider in `index.html` that creates a `.lens-wrap` section containing a `.lens-head` intro and a `.lens-grid` of two `.lens-card` items with the supplied titles, descriptive copy, and Vimeo embeds.  
- Added scoped CSS for the new section (`.lens-wrap`, `.lens-head`, `.lens-grid`, `.lens-card`, `.lens-video`) to provide card styling and a responsive layout that is single-column on mobile and two-column on desktop.  
- Embedded each Vimeo player as an `<iframe>` with `loading="lazy"` and no autoplay so embeds only load on demand and playback requires a user action.  
- Change is limited to `index.html` and preserves the existing private tours slider and page structure.

### Testing
- Ran `git diff --check` which returned `diff-check-ok` indicating no whitespace/diff errors.  
- No automated unit tests exist for static markup in this repo; visual/manual QA in a browser is recommended to confirm responsive layout and lazy-loading behavior of the embeds.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebff493f9083309ef83db8cab382ac)