### PR TITLE
Update tours private section messaging and i18n

### DIFF
--- a/assets/common/i18n.js
+++ b/assets/common/i18n.js
@@ -433,7 +433,7 @@
       'tours.h1':         'Explorez Nos Excursions',
       'tours.sub':        'Choisissez l\'aventure qui vous correspond. Expériences privées sur mesure ou aventures partagées à prix accessible.',
       'tours.priv.lbl':   'Expériences Privées',
-      'tours.priv.h2':    'Uniquement Pour Vous et Votre Groupe',
+      'tours.priv.h2.html':'<span style="color:var(--coral)">Vivez-le</span> sans la foule.',
       'tours.shar.lbl':   'Expériences Partagées',
       'tours.shar.h2':    'Vivez l\'Aventure à Petit Prix',
 
@@ -886,7 +886,7 @@
       'tours.h1':         'Explora Nuestros Tours',
       'tours.sub':        'Elige la aventura que se adapte a ti. Experiencias privadas a tu medida o aventuras compartidas a precio accesible.',
       'tours.priv.lbl':   'Experiencias Privadas',
-      'tours.priv.h2':    'Solo Para Ti y Tu Grupo',
+      'tours.priv.h2.html':'<span style="color:var(--coral)">Vívelo</span> sin multitudes.',
       'tours.shar.lbl':   'Experiencias Compartidas',
       'tours.shar.h2':    'Vive la Aventura a Buen Precio',
 

--- a/tours.html
+++ b/tours.html
@@ -381,8 +381,8 @@ footer{background:var(--navy);padding:52px 20px 28px;color:rgba(255,255,255,.52)
 </div>
 <section class="sec" style="background:#ffffff">
   <div class="lbl" data-i18n="tours.priv.lbl">Private Experiences</div>
-  <h2 class="h2" data-i18n="tours.priv.h2">100% private - just your group.</h2>
-  <p class="sub">Certified hosts, newest vans, zero shared groups. Price drops as your group grows.</p>
+  <h2 class="h2" data-i18n-html="tours.priv.h2.html"><span style="color:var(--coral)">Experience it</span> without the crowds.</h2>
+  <p class="sub">Travel should feel open, calm, and real. That’s why everything we do is built around giving you space. Space to enjoy the water without people around you. Space to move at your own rhythm. Space to connect with the place and the people you’re with. You won’t be part of a group or following a script. You’ll have a local host who understands how to create those moments naturally, without forcing anything. The experience becomes richer when shared, and as your group grows, the cost per person becomes more favorable.</p>
   <div class="cards-grid"><article class="tc">
   <div class="tc-thumb" style="background:linear-gradient(135deg,#0A4D5C,#1DA5B4)"><a href="tour-turtles-cenotes.html" class="tc-thumb-link" tabindex="-1" aria-hidden="true">
     <img src="https://images.pexels.com/photos/847393/pexels-photo-847393.jpeg?auto=compress&cs=tinysrgb&w=600&q=80" alt="Sea Turtles & Cenote Experience" loading="eager" fetchpriority="high" decoding="async">


### PR DESCRIPTION
### Motivation
- Refresh the copy for the "Private Experiences" section to better communicate the brand tone about space, calm, and group pricing value. 
- Ensure the highlighted phrase in the new heading can be styled (orange) and preserved in localized strings. 

### Description
- Replaced the heading and supporting paragraph in `tours.html` with the new copy: `Experience it` highlighted in coral and the longer brand-focused paragraph about space and group value. 
- Switched the French and Spanish i18n entries in `assets/common/i18n.js` from `tours.priv.h2` to an HTML-capable key `tours.priv.h2.html` so the highlighted phrase can be rendered in localized pages. 
- Kept the change localized to the tours page and i18n file so existing layout and components are unaffected. 

### Testing
- Ran a whitespace/diff check (`diff --check`) to ensure no formatting issues and it passed. 
- Verified the new `tours.priv.h2.html` keys are present in `assets/common/i18n.js` and the updated heading is present in `tours.html` via file search validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec04e3c7ac8330b550fe67a135e379)