### PR TITLE
Fix Private Fishing Experience slider image path

### DIFF
--- a/tour-fishing.html
+++ b/tour-fishing.html
@@ -450,8 +450,8 @@ footer{background:var(--navy);padding:52px 20px 28px;color:rgba(255,255,255,.52)
 </div>
 
 <div class="ps" id="photoSlider">
-    <div class="ps-track" id="psTrack"><div class="ps-slide"><img decoding="async" src="assets/tour-sliders/tour-fishing/slide-01.jpg" alt="Private Fishing Experience photo 1" loading="eager" fetchpriority="high"></div></div>
-  <div class="ps-ctr" id="psCtr">1 / 4</div>
+    <div class="ps-track" id="psTrack"><div class="ps-slide"><img decoding="async" src="assets/tour-sliders/privados/fishingexperience/01.jpg" alt="Private Fishing Experience photo 1" loading="eager" fetchpriority="high"></div></div>
+  <div class="ps-ctr" id="psCtr">1 / 1</div>
 </div>
 <div class="ps-nav">
   <button class="ps-btn ps-prev" id="psPrev" aria-label="Previous photo">&#8592;</button>


### PR DESCRIPTION
### Motivation
- A new image was added at `assets/tour-sliders/privados/fishingexperience/01.jpg` and the tour page needed to reference it so the slider displays the uploaded photo.
- The visible slider counter needed to match the actual number of slides to prevent a UI mismatch.

### Description
- Replaced the slider `img` source in `tour-fishing.html` from `assets/tour-sliders/tour-fishing/slide-01.jpg` to `assets/tour-sliders/privados/fishingexperience/01.jpg`.
- Updated the slider counter in `tour-fishing.html` from `1 / 4` to `1 / 1`.
- No additional slider markup or behavior changes were made.

### Testing
- Ran `ls assets/tour-sliders/privados/fishingexperience` and confirmed `01.jpg` is present (success).
- Inspected the slider block with `sed -n '430,490p' tour-fishing.html` and verified the `img` `src` points to the new path (success).
- Searched the file with `rg -n "tour-fishing/slide-01|ps-ctr\" id=\"psCtr\""` and confirmed the old reference is gone and the counter reads `1 / 1` (success).
- Printed the updated lines with `nl -ba tour-fishing.html | sed -n '448,458p'` to capture the exact changes (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3bc4552e08330b0453ad317605100)